### PR TITLE
Adds automated travis CI tests for Python 3.4 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
 
 env:
   - WAGTAIL_VERSION=1.5.1
   - WAGTAIL_VERSION=1.5.2
+  - WAGTAIL_VERSION=1.5.3
 
 # command to install dependencies
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
 
 env:
-  - WAGTAIL_VERSION=1.5.1
-  - WAGTAIL_VERSION=1.5.2
   - WAGTAIL_VERSION=1.5.3
 
 # command to install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 1.2.3 (xx.xx.xx) IN DEVELOPMENT
 ---------------------------------
 
-* Added CONTRIBUTORS.rst
+* Added tests for Python 3.4 and 3.5 to confirm compatibility (Andy Babic)
+* Added CONTRIBUTORS.rst (Andy Babic)
 
 
 1.2.2 (06.07.2016)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ It's an extension for Torchbox's [Wagtail CMS](https://github.com/torchbox/wagta
 
 #### Compatibility
 
-The current version of wagtailmenus is compatible with Wagtail >= 1.5, and Python 2.7.
-
-Support for Python 3.2-3.4 is planned for version 1.3 (if you'd like to help, pull requests are welcome).
+The current version of wagtailmenus is compatible with Wagtail >= 1.5, and Python 2.7, 3.4 and 3.5.
 
 ## What does it do?
 


### PR DESCRIPTION
Related to #14 

Tests seem to be passing just fine with wagtail 1.5.3 in Python 3.4 & 3.5.

Python 3.3 failed, because of the wagtail dependency automatically using Django 1.9, which needs `find_spec` to get going (which wasn't added until Python 3.4)

Tests on wagtail versions 1.5.1 and 1.5.2 failed because of the `html5lib` bug (fixed by 1.5.3), so those tests have been removed.