### PR TITLE
Apply `active` to custom url links if currently at that URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Changelog
   allow flat menus defined for the default site to be used as fall-backs, in
   cases where the 'current' site doesn't have its own menus set up with the
   specified handle.
+* Apply `active` classes to menu items that link to custom URLs (if
+  `request.path` and `link_url` are exact matches).
 
 
 1.4.1 (02.10.2016) 

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -110,6 +110,7 @@ def main_menu(
             current_site=site,
             current_page=current_page,
             current_page_ancestor_ids=ancestor_ids,
+            request_path=r.path,
             check_for_children=max_levels > 1,
             allow_repeating_parents=allow_repeating_parents,
             apply_active_classes=apply_active_classes,
@@ -164,6 +165,7 @@ def section_menu(
         current_site=site,
         current_page=current_page,
         current_page_ancestor_ids=ancestor_ids,
+        request_path=r.path,
         check_for_children=max_levels > 1,
         allow_repeating_parents=allow_repeating_parents,
         original_menu_tag='section_menu'
@@ -244,6 +246,7 @@ def flat_menu(
         current_site=site,
         current_page=current_page,
         current_page_ancestor_ids=ancestor_ids,
+        request_path=r.path,
         check_for_children=max_levels > 1,
         allow_repeating_parents=allow_repeating_parents,
         apply_active_classes=apply_active_classes,
@@ -331,6 +334,7 @@ def sub_menu(
         current_site=site,
         current_page=current_page,
         current_page_ancestor_ids=ancestor_ids,
+        request_path=r.path,
         check_for_children=not stop_at_this_level,
         allow_repeating_parents=allow_repeating_parents,
         apply_active_classes=apply_active_classes,
@@ -392,7 +396,7 @@ def children_menu(
 
 def prime_menu_items(
     menu_items, current_site, current_page, current_page_ancestor_ids,
-    check_for_children=False, allow_repeating_parents=True,
+    request_path, check_for_children=False, allow_repeating_parents=True,
     apply_active_classes=True, use_specific=False, original_menu_tag='',
 ):
     """
@@ -512,6 +516,8 @@ def prime_menu_items(
 
         elif page is None:
             setattr(item, 'href', item.link_url + item.url_append)
+            if apply_active_classes and item.link_url == request_path:
+                setattr(item, 'active_class', app_settings.ACTIVE_CLASS)
             primed_menu_items.append(item)
 
     return primed_menu_items

--- a/wagtailmenus/tests/fixtures/test.json
+++ b/wagtailmenus/tests/fixtures/test.json
@@ -211,6 +211,18 @@
     }
 },
 {
+    "model": "wagtailmenus.flatmenuitem",
+    "pk": 8,
+    "fields": {
+        "sort_order": 4,
+        "link_page": null,
+        "link_url": "/about-us/meet-the-team/custom-url/",
+        "link_text": "Meet the team's pets",
+        "url_append": "",
+        "menu": 2
+    }
+},
+{
     "model": "sites.site",
     "pk": 1,
     "fields": {

--- a/wagtailmenus/tests/test_frontend.py
+++ b/wagtailmenus/tests/test_frontend.py
@@ -563,7 +563,19 @@ class TestTemplateTags(TestCase):
 
         # Assertions to compare rendered HTML against expected HTML
         menu_html = soup.find(id='nav-footer').decode()
-        expected_menu_html = """<div id="nav-footer"><div class="flat-menu footer with_heading"><h4>Important links</h4><ul><li class=""><a href="/legal/accessibility/">Accessibility</a></li><li class=""><a href="/legal/privacy-policy/">Privacy policy</a></li><li class=""><a href="/legal/terms-and-conditions/">Terms and conditions</a></li></ul></div></div>"""
+        expected_menu_html = """
+        <div id="nav-footer">
+            <div class="flat-menu footer with_heading">
+                <h4>Important links</h4>
+                <ul>
+                    <li class=""><a href="/legal/accessibility/">Accessibility</a></li>
+                    <li class=""><a href="/legal/privacy-policy/">Privacy policy</a></li>
+                    <li class=""><a href="/legal/terms-and-conditions/">Terms and conditions</a></li>
+                    <li class=""><a href="/about-us/meet-the-team/custom-url/">Meet the team's pets</a></li>
+                </ul>
+            </div>
+        </div>
+        """
         self.assertHTMLEqual(menu_html, expected_menu_html)
 
         response = self.client.get('/legal/privacy-policy/')
@@ -571,7 +583,39 @@ class TestTemplateTags(TestCase):
 
         # Assertions to compare rendered HTML against expected HTML
         menu_html = soup.find(id='nav-footer').decode()
-        expected_menu_html = """<div id="nav-footer"><div class="flat-menu footer with_heading"><h4>Important links</h4><ul><li class=""><a href="/legal/accessibility/">Accessibility</a></li><li class="active"><a href="/legal/privacy-policy/">Privacy policy</a></li><li class=""><a href="/legal/terms-and-conditions/">Terms and conditions</a></li></ul></div></div>"""
+        expected_menu_html = """
+        <div id="nav-footer">
+            <div class="flat-menu footer with_heading">
+                <h4>Important links</h4>
+                <ul>
+                    <li class=""><a href="/legal/accessibility/">Accessibility</a></li>
+                    <li class="active"><a href="/legal/privacy-policy/">Privacy policy</a></li>
+                    <li class=""><a href="/legal/terms-and-conditions/">Terms and conditions</a></li>
+                    <li class=""><a href="/about-us/meet-the-team/custom-url/">Meet the team's pets</a></li>
+                </ul>
+            </div>
+        </div>
+        """
+        self.assertHTMLEqual(menu_html, expected_menu_html)
+
+        response = self.client.get('/about-us/meet-the-team/custom-url/')
+        soup = BeautifulSoup(response.content, 'html5lib')
+
+        # Assertions to compare rendered HTML against expected HTML
+        menu_html = soup.find(id='nav-footer').decode()
+        expected_menu_html = """
+        <div id="nav-footer">
+            <div class="flat-menu footer with_heading">
+                <h4>Important links</h4>
+                <ul>
+                    <li class=""><a href="/legal/accessibility/">Accessibility</a></li>
+                    <li class=""><a href="/legal/privacy-policy/">Privacy policy</a></li>
+                    <li class=""><a href="/legal/terms-and-conditions/">Terms and conditions</a></li>
+                    <li class="active"><a href="/about-us/meet-the-team/custom-url/">Meet the team's pets</a></li>
+                </ul>
+            </div>
+        </div>
+        """
         self.assertHTMLEqual(menu_html, expected_menu_html)
 
     def test_custom_page_menu_output(self):


### PR DESCRIPTION
* Supply `prime_menu_items` with `request.path`, which will be compared with non-page-link menu items to check if they should have the `active` class applied to them.
* Add test to show the active class applying correctly when viewing a custom URL

Fixes #38 