### PR TITLE
Fix for #52 (migration issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Changelog
   The `check_for_chilren` value passed to `has_submenu_items()` is now always
   True. Since removing would add breaking changes, it will be removed in a 
   later feature release.
+* Fixed a migration-related issue that was django to create new migrations for
+  the app.
+* Fixed an issue where not all help text was marked for translation.
 
 
 1.5.0 (05.10.2016)

--- a/wagtailmenus/migrations/0012_auto_20160419_0039.py
+++ b/wagtailmenus/migrations/0012_auto_20160419_0039.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='flatmenuitem',
             name='url_append',
-            field=models.CharField(blank=True, help_text=b"Use this to optionally append a #hash or querystring to the above page's URL.", max_length=255, verbose_name='append to URL'),
+            field=models.CharField(blank=True, help_text="Use this to optionally append a #hash or querystring to the above page's URL.", max_length=255, verbose_name='append to URL'),
         ),
         migrations.AlterField(
             model_name='mainmenu',
@@ -51,6 +51,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='mainmenuitem',
             name='url_append',
-            field=models.CharField(blank=True, help_text=b"Use this to optionally append a #hash or querystring to the above page's URL.", max_length=255, verbose_name='append to URL'),
+            field=models.CharField(blank=True, help_text="Use this to optionally append a #hash or querystring to the above page's URL.", max_length=255, verbose_name='append to URL'),
         ),
     ]

--- a/wagtailmenus/models.py
+++ b/wagtailmenus/models.py
@@ -119,7 +119,7 @@ class MenuItem(models.Model):
         verbose_name=_("append to URL"),
         max_length=255,
         blank=True,
-        help_text=(
+        help_text=_(
             "Use this to optionally append a #hash or querystring to the "
             "above page's URL.")
     )


### PR DESCRIPTION
The use of binary strings in a wagtailmenus migration are causing some environments to detect changes in wagtailmenus and attempt to create a new migration. This fix doctors the old migration to replace the binary strings with regular python strings, and also wraps the help_text for the problematic field for translation (likely to be the original cause)