### PR TITLE
Create a context_processor to handle filling of missing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,19 @@ Changelog
 1.6.0 (XX.XX.XXX) IN DEVELOPMENT
 ---------------------------------
 
-* Improved the confirmation messages when saving a menu
+* Improved confirmation messages when saving a menu in the admin area.
 * Added a new test to submit the `MainMenu` edit form and check that
   it behaves as expected.
+* Added a new `context_processor` to handle some of the logic that was
+  previously being done in template tags. Django's `SimpleLazyObject` class is
+  used to reduce the overhead as much as possible, only doing the work when the
+  values are accessed by menu tags.
+* Added the `WAGTAILMENUS_GUESS_TREE_POSITION_FROM_PATH` setting to allow
+  developers to disable the 'guess tree position from path' functionality 
+  that comes into play when serving custom views, where the `before_serve_page`
+  hook isn't activated, and `wagtailmenu_params_helper()` in `wagtail_hooks.py`
+  doesn't get to add it's helpful values to the request/context.
+
 
 
 1.5.1 (10.10.2016) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 Changelog
 =========
 
-1.5.2 (XX.XX.XXX) IN DEVELOPMENT
+1.6.1 (XX.XX.XXX) IN DEVELOPMENT
 ---------------------------------
 
-* Wait and see!
+
+1.6.0 (XX.XX.XXX) IN DEVELOPMENT
+---------------------------------
+
+* Improved the confirmation messages when saving a menu
+* Added a new test to submit the `MainMenu` edit form and check that
+  it behaves as expected.
 
 
 1.5.1 (10.10.2016) 

--- a/README.md
+++ b/README.md
@@ -40,21 +40,39 @@ Each tag comes with a default template that's designed to be fully accessible an
 
 ## Installation instructions
 
-### For wagtail `1.5` and up
-
 1. Install the package using pip: `pip install wagtailmenus`.
 2. Add `wagtail.contrib.modeladmin` to `INSTALLED_APPS` in your project settings, if it's not there already.
 3. Add `wagtailmenus` to `INSTALLED_APPS` in your project settings.
-4. Run `python manage.py migrate wagtailmenus` to set up the initial database tables.
+4. Add `wagtailmenus.context_processors.wagtailmenus` to the `context_processors` list in your `TEMPLATES` setting. The setting should look something like this:
+```python
 
-### For wagtail `1.4.5` and below
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            os.path.join(PROJECT_ROOT, 'templates'),
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.request',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                'django.contrib.messages.context_processors.messages',
+                'wagtail.contrib.settings.context_processors.settings',
+                'wagtailmenus.context_processors.wagtailmenus',
+            ],
+        },
+    },
+]
 
-Since version `1.2`, watailmenus has depended on the `wagtail.contrib.modeladmin` package that was added to wagtail in `1.5`. However, earlier versions of wagtailmenus can be used with earlier versions of wagtail with the help of another third-party package, [wagtailmodeladmin](https://github.com/rkhleics/wagtailmodeladmin).
+```
+5. Run `python manage.py migrate wagtailmenus` to set up the initial database tables.
 
-1. Install `wagtailmodeladmin` by following these instructions: https://github.com/rkhleics/wagtailmodeladmin.
-2. Install this package using pip: `pip install wagtailmenus>=1.1.1,<1.2.0`.
-3. Add `wagtailmenus` to `INSTALLED_APPS` in your project settings (after `wagtailmodeladmin` and before your `core` app).
-4. Run `python manage.py migrate wagtailmenus` to set up the initial database tables.
 
 ### Additional steps for `MenuPage` usage
 
@@ -342,6 +360,7 @@ You can override some of wagtailmenus' default behaviour by adding one of more o
 - **`WAGTAILMENUS_MAINMENU_MENU_ICON`** (default: `'list-ol'`): Use this to change the icon used to represent `MainMenu` in the Wagtail admin area.
 - **`WAGTAILMENUS_FLATMENU_MENU_ICON`** (default: `'list-ol'`): Use this to change the icon used to represent `FlatMenu` in the Wagtail admin area.
 - **`WAGTAILMENUS_SECTION_ROOT_DEPTH`** (default: `3`): Use this to specify the 'depth' value of a project's 'section root' pages. For most Wagtail projects, this should be `3` (Root page = 1, Home page = 2), but it may well differ, depending on the needs of the project.
+- **`WAGTAILMENUS_GUESS_TREE_POSITION_FROM_PATH`** (default: `True`): When not using wagtail's routing/serving mechanism to serve page objects, wagtailmenus can use the request path to attempt to identify a 'current' page, 'section root' page, allowing `{% section_menu %}` and active item highlighting to work. If this functionality is not required for your project, you can disable it by setting this value to `False`.
 - **`WAGTAILMENUS_FLAT_MENUS_FALL_BACK_TO_DEFAULT_SITE_MENUS`** (default: `False`): The default value used for `fall_back_to_default_site_menus` option of the `{% flat_menu %}` tag when a parameter value isn't provided.
 - **`WAGTAILMENUS_DEFAULT_MAIN_MENU_TEMPLATE`** (default: `'menus/main_menu.html'`): The name of the template used for rendering by the `{% main_menu %}` tag when a `template` parameter value isn't provided.
 - **`WAGTAILMENUS_DEFAULT_FLAT_MENU_TEMPLATE`** (default: `'menus/flat_menu.html'`): The name of the template used for rendering by the `{% flat_menu %}` tag when a `template` parameter value isn't provided.

--- a/wagtailmenus/app_settings.py
+++ b/wagtailmenus/app_settings.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 from django.conf import settings
 
 ACTIVE_CLASS = getattr(
@@ -15,6 +17,9 @@ FLATMENU_MENU_ICON = getattr(
 
 SECTION_ROOT_DEPTH = getattr(
     settings, 'WAGTAILMENUS_SECTION_ROOT_DEPTH', 3)
+
+GUESS_TREE_POSITION_FROM_PATH = getattr(
+    settings, 'WAGTAILMENUS_GUESS_TREE_POSITION_FROM_PATH', True)
 
 DEFAULT_MAIN_MENU_TEMPLATE = getattr(
     settings, 'WAGTAILMENUS_DEFAULT_MAIN_MENU_TEMPLATE',

--- a/wagtailmenus/app_settings.py
+++ b/wagtailmenus/app_settings.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.conf import settings
 

--- a/wagtailmenus/context_processors.py
+++ b/wagtailmenus/context_processors.py
@@ -1,0 +1,57 @@
+from __future__ import unicode_literals
+
+from django.http import Http404
+from django.utils.functional import SimpleLazyObject
+
+from .app_settings import SECTION_ROOT_DEPTH, GUESS_TREE_POSITION_FROM_PATH
+
+
+def wagtailmenus(request):
+
+    def _get_value_dict():
+        current_page = request.META.get('WAGTAILMENUS_CURRENT_PAGE')
+        section_root = request.META.get('WAGTAILMENUS_CURRENT_SECTION_ROOT')
+        ancestor_ids = request.META.get(
+            'WAGTAILMENUS_CURRENT_PAGE_ANCESTOR_IDS')
+        match = None
+        site = request.site
+
+        if GUESS_TREE_POSITION_FROM_PATH and not current_page:
+            path_components = [pc for pc in request.path.split('/') if pc]
+            # Keep trying to find a page using the path components until there
+            # are no components left, or a page has been identified
+            first_run = True
+            while path_components and match is None:
+                try:
+                    match, args, kwargs = site.root_page.specific.route(
+                        request, path_components)
+                    ancestor_ids = match.get_ancestors(inclusive=True).filter(
+                        depth__gte=SECTION_ROOT_DEPTH
+                    ).values_list('id', flat=True)
+                    if first_run:
+                        # A page was found matching the exact path, so it's
+                        # safe to assume it's the 'current page'
+                        current_page = match
+                except Http404:
+                    # No match found, so remove a path component and try again
+                    path_components.pop()
+                first_run = False
+
+        best_match = current_page or match
+        if GUESS_TREE_POSITION_FROM_PATH and not section_root and best_match:
+            if best_match.depth == SECTION_ROOT_DEPTH:
+                section_root = best_match
+            elif best_match.depth > SECTION_ROOT_DEPTH:
+                # Attempt to identify the section root page from best_match
+                section_root = best_match.get_ancestors().filter(
+                    depth__exact=SECTION_ROOT_DEPTH).first()
+
+        return {
+            'current_page': current_page,
+            'section_root': section_root,
+            'current_page_ancestor_ids': ancestor_ids or (),
+        }
+
+    return {
+        'wagtailmenus_vals': SimpleLazyObject(_get_value_dict)
+    }

--- a/wagtailmenus/managers.py
+++ b/wagtailmenus/managers.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from django.db import models
 
 

--- a/wagtailmenus/models.py
+++ b/wagtailmenus/models.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, unicode_literals
+
 from copy import deepcopy
 from django.db import models
 from django.core.exceptions import ValidationError

--- a/wagtailmenus/panels.py
+++ b/wagtailmenus/panels.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from wagtail.wagtailadmin.edit_handlers import (
     FieldPanel, FieldRowPanel, MultiFieldPanel, ObjectList)

--- a/wagtailmenus/panels.py
+++ b/wagtailmenus/panels.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from wagtail.wagtailadmin.edit_handlers import (
     FieldPanel, FieldRowPanel, MultiFieldPanel, ObjectList)
 from django.utils.translation import ugettext_lazy as _

--- a/wagtailmenus/settings/base.py
+++ b/wagtailmenus/settings/base.py
@@ -69,6 +69,7 @@ TEMPLATES = [
                 'django.template.context_processors.tz',
                 'django.contrib.messages.context_processors.messages',
                 'wagtail.contrib.settings.context_processors.settings',
+                'wagtailmenus.context_processors.wagtailmenus'
             ],
         },
     },

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -99,13 +99,6 @@ def section_menu(
         # The section root couldn't be identified.
         return ''
 
-    """
-    We want `section_root` to have the same attributes as primed menu
-    items, so it can be used in the same way in a template if required.
-    """
-    setattr(section_root, 'text', section_root.title)
-    setattr(section_root, 'href', section_root.relative_url(site))
-
     children_qs = get_children_for_menu(section_root, 'section_menu',
                                         use_specific)
     menu_items = prime_menu_items(
@@ -123,16 +116,22 @@ def section_menu(
     If section_root has a `modify_submenu_items` method, call it to modify
     the list of menu_items appropriately.
     """
-    if hasattr(section_root, 'modify_submenu_items'):
+    if (
+        hasattr(section_root, 'modify_submenu_items') or
+        hasattr(section_root.specific_class, 'modify_submenu_items')
+    ):
+        if type(section_root) is Page:
+            section_root = section_root.specific
         menu_items = section_root.modify_submenu_items(
             menu_items, current_page, ancestor_ids, site,
             allow_repeating_parents, apply_active_classes, 'section_menu')
 
     """
-    Now we know the subnav/repetition situation, we can set the `active_class`
-    for the section_root page (much like `prime_menu_items` does for pages
-    with children.
+    We want `section_root` to have the same attributes as primed menu
+    items, so it can be used in the same way in a template if required.
     """
+    setattr(section_root, 'text', section_root.title)
+    setattr(section_root, 'href', section_root.relative_url(site))
     if apply_active_classes:
         active_class = ''
         if current_page and section_root.pk == current_page.pk:

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -73,6 +73,18 @@ class CMSUsecaseTests(WebTest):
         assert 'The flat menu could not be saved due to errors' in response
         assert 'Site and handle must create a unique combination.' in response
 
+    def test_main_menu_save_success(self):
+        get_user_model().objects._create_user(
+            username='test1', email='test1@email.com', password='password',
+            is_staff=True, is_superuser=True)
+
+        edit_view = self.app.get(
+            '/admin/wagtailmenus/mainmenu/edit/1/', user='test1')
+        form = edit_view.forms[2]
+        response = form.submit().follow()
+
+        assert 'Main menu updated successfully.' in response
+
 
 class TestSuperUser(TransactionTestCase):
     fixtures = ['test.json']
@@ -98,8 +110,6 @@ class TestSuperUser(TransactionTestCase):
     def test_mainmenu_edit(self):
         response = self.client.get(
             '/admin/wagtailmenus/mainmenu/edit/1/')
-        self.assertEqual(response.status_code, 200)
-
         # Test 'get_error_message' method on view for additional coverage
         view = response.context['view']
         self.assertTrue(view.get_error_message())

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -1,4 +1,5 @@
-from __future__ import absolute_import, unicode_literals
+from __future__ import unicode_literals
+
 from copy import copy
 
 from django import forms

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from copy import copy
 

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -50,10 +50,12 @@ class MainMenuEditView(ModelFormView):
         self.instance_pk = unquote(instance_pk)
         self.pk_safe = quote(self.instance_pk)
         self.site = get_object_or_404(Site, id=self.instance_pk)
-        self.edit_url = self.model_admin.url_helper.get_action_url(
-            'edit', self.instance_pk)
         self.instance = self.model.get_for_site(self.site)
         self.instance.save()
+
+    @property
+    def edit_url(self):
+        return self.url_helper.get_action_url('edit', self.instance_pk)
 
     def get_meta_title(self):
         return _('Editing %s') % self.opts.verbose_name
@@ -85,9 +87,7 @@ class MainMenuEditView(ModelFormView):
 
     def form_valid(self, form):
         form.save()
-        messages.success(
-            self.request, _("%s updated.") % capfirst(self.model_name)
-        )
+        messages.success(self.request, _("Main menu updated successfully."))
         return redirect(self.edit_url)
 
     def get_error_message(self):
@@ -131,8 +131,7 @@ class FlatMenuCopyView(EditView):
         return kwargs
 
     def get_success_message(self, instance):
-        return _("{model_name} '{instance}' created.").format(
-            model_name=capfirst(self.opts.verbose_name), instance=instance)
+        return _("Flat menu '{instance}' created.").format(instance=instance)
 
     def get_template_names(self):
         return ['wagtailmenus/flatmenu_copy.html']

--- a/wagtailmenus/wagtail_hooks.py
+++ b/wagtailmenus/wagtail_hooks.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf.urls import url
 from django.contrib.admin.utils import quote
 from django.utils.safestring import mark_safe
@@ -115,6 +117,7 @@ def wagtailmenu_params_helper(page, request, serve_args, serve_kwargs):
         section_root = section_root.specific
     ancestor_ids = page.get_ancestors().values_list('id', flat=True)
     request.META.update({
-        'CURRENT_SECTION_ROOT': section_root,
-        'CURRENT_PAGE_ANCESTOR_IDS': ancestor_ids,
+        'WAGTAILMENUS_CURRENT_SECTION_ROOT': section_root,
+        'WAGTAILMENUS_CURRENT_PAGE': page,
+        'WAGTAILMENUS_CURRENT_PAGE_ANCESTOR_IDS': ancestor_ids,
     })


### PR DESCRIPTION
- Added a `wagtailmenus` context processor to add reliable values to context
- Removed untidy/hacky patching functionality from `get_attrs_from_context()`
- Added a setting to toggle tree position matching on request path on and off
- Updated installation instructions in README and added note for the new `WAGTAILMENUS_GUESS_TREE_POSITION_FROM_PATH` setting