### PR TITLE
Add some override styles to the form pages to improve layout of fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Changelog
 * Improved confirmation messages when saving a menu in the admin area.
 * Added a new test to submit the `MainMenu` edit form and check that
   it behaves as expected.
+* Added some styles to menu add/edit/copy views to improve the UI.
 * Added a new `context_processor` to handle some of the logic that was
   previously being done in template tags. Django's `SimpleLazyObject` class is
   used to reduce the overhead as much as possible, only doing the work when the

--- a/wagtailmenus/models.py
+++ b/wagtailmenus/models.py
@@ -167,8 +167,8 @@ class MenuItem(models.Model):
 
     panels = (
         PageChooserPanel('link_page'),
-        FieldPanel('url_append'),
         FieldPanel('link_url'),
+        FieldPanel('url_append'),
         FieldPanel('link_text'),
         FieldPanel('handle'),
         FieldPanel('allow_subnav'),

--- a/wagtailmenus/static/wagtailmenus/css/menu-edit.css
+++ b/wagtailmenus/static/wagtailmenus/css/menu-edit.css
@@ -1,0 +1,55 @@
+.object .multiple > li {
+    padding-right: 3.5%;
+}
+
+@media screen and (min-width: 50em) {
+
+    label {
+        padding-right: 12px;
+        max-width: 165px;
+        text-align: right;
+        width: 29%;
+    }
+
+    .field-content {
+        width: 70.6%
+    }
+
+    .object fieldset {
+        float: none;
+        width: 100%;
+    }
+
+    .object .multiple {
+        width: 100%
+    }
+
+    .multiple > li {
+        padding-right: 0;
+    }
+
+    .multiple fieldset {
+        width: 100%;
+    }
+
+    .multiple label {
+        max-width: 146px;
+        width: 27%;
+    }
+
+    .multiple .field-content {
+        width: 72.6%
+    }
+
+}
+
+@media screen and (min-width: 60em) {
+
+    .multiple label {
+        width: 23%;
+    }
+
+    .multiple .field-content {
+        width: 76.6%
+    }
+}

--- a/wagtailmenus/templates/wagtailmenus/mainmenu_edit.html
+++ b/wagtailmenus/templates/wagtailmenus/mainmenu_edit.html
@@ -1,12 +1,8 @@
 {% extends "modeladmin/create.html" %}
 {% load i18n %}
 
-{% block css %}
-    {{ block.super }}
-    <link rel="stylesheet" href="{{ STATIC_URL }}wagtailmenus/css/menu-edit.css" type="text/css" />
-{% endblock %}
-
 {% block content %}
+    
     <header class="nice-padding merged">
         <div class="row">
             <div class="left">
@@ -53,10 +49,10 @@
 {% block extra_css %}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ edit_handler.form.media.css }}
-    {{ site_switcher.media.css }}
+    {{ view.media.css }}
 {% endblock %}
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}
-    {{ site_switcher.media.js }}
+    {{ view.media.js }}
 {% endblock %}

--- a/wagtailmenus/templates/wagtailmenus/mainmenu_edit.html
+++ b/wagtailmenus/templates/wagtailmenus/mainmenu_edit.html
@@ -1,6 +1,11 @@
 {% extends "modeladmin/create.html" %}
 {% load i18n %}
 
+{% block css %}
+    {{ block.super }}
+    <link rel="stylesheet" href="{{ STATIC_URL }}wagtailmenus/css/menu-edit.css" type="text/css" />
+{% endblock %}
+
 {% block content %}
     <header class="nice-padding merged">
         <div class="row">

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -90,7 +90,6 @@ class MainMenuEditView(ModelFormView):
         context.update({
             'site': self.site,
             'site_switcher': self.site_switcher,
-            'view': self,
         })
         return context
 

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -55,6 +55,13 @@ class MainMenuEditView(ModelFormView):
         self.instance.save()
 
     @property
+    def media(self):
+        media = super(MainMenuEditView, self).media
+        if self.site_switcher:
+            media += self.site_switcher.media
+        return media
+
+    @property
     def edit_url(self):
         return self.url_helper.get_action_url('edit', self.instance_pk)
 
@@ -83,6 +90,7 @@ class MainMenuEditView(ModelFormView):
         context.update({
             'site': self.site,
             'site_switcher': self.site_switcher,
+            'view': self,
         })
         return context
 

--- a/wagtailmenus/wagtail_hooks.py
+++ b/wagtailmenus/wagtail_hooks.py
@@ -24,6 +24,9 @@ class MainMenuAdmin(ModelAdmin):
     edit_view_class = MainMenuEditView
     add_to_settings_menu = True
 
+    def get_form_view_extra_css(self):
+        return ['wagtailmenus/css/menu-edit.css'] + self.form_view_extra_css
+
     def get_admin_urls_for_registration(self):
         return (
             url(self.url_helper.get_action_url_pattern('index'),

--- a/wagtailmenus/wagtail_hooks.py
+++ b/wagtailmenus/wagtail_hooks.py
@@ -70,6 +70,9 @@ class FlatMenuAdmin(ModelAdmin):
     ordering = ('-site__is_default_site', 'site__hostname', 'handle')
     add_to_settings_menu = True
 
+    def get_form_view_extra_css(self):
+        return ['wagtailmenus/css/menu-edit.css'] + self.form_view_extra_css
+
     def copy_view(self, request, instance_pk):
         kwargs = {'model_admin': self, 'instance_pk': instance_pk}
         return FlatMenuCopyView.as_view(**kwargs)(request)


### PR DESCRIPTION
Relates to issue #63.

Improves the readability of the forms by right-aligning labels and tweeking the width of labels/fields/formsets slightly.

Flat Menu edit:

![screenshot 2016-10-24 at 11 58 36](https://cloud.githubusercontent.com/assets/7779588/19643276/71ec6704-99e1-11e6-991d-c21be4fec4a8.png)

Main Menu edit:

![screenshot 2016-10-24 at 11 58 49](https://cloud.githubusercontent.com/assets/7779588/19643280/743329ee-99e1-11e6-98fc-98d350ba33de.png)



