### PR TITLE
Fix voor pip install requirements.txt

### DIFF
--- a/wagtailmenus/__init__.py
+++ b/wagtailmenus/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, unicode_literals
-from django.core.exceptions import ImproperlyConfigured
 from .app_settings import Settings
 
 __version__ = '2.1.0'
@@ -35,6 +34,8 @@ def get_main_menu_model():
     if no custom model is defined.
     """
     from django.apps import apps
+    from django.core.exceptions import ImproperlyConfigured
+
     model_string = get_main_menu_model_string()
     try:
         return apps.get_model(model_string)
@@ -57,6 +58,8 @@ def get_flat_menu_model():
     if no custom model is defined.
     """
     from django.apps import apps
+    from django.core.exceptions import ImproperlyConfigured
+
     model_string = get_flat_menu_model_string()
     try:
         return apps.get_model(model_string)


### PR DESCRIPTION
The `__init__.py` file should not import any other packages, since that could break a `pip install` when it loads this file to get the `__version__`.

This fixes https://github.com/rkhleics/wagtailmenus/issues/93