### PR TITLE
Prevent imports occurring during pip install

### DIFF
--- a/wagtailmenus/__init__.py
+++ b/wagtailmenus/__init__.py
@@ -1,9 +1,15 @@
 from __future__ import absolute_import, unicode_literals
-from .app_settings import Settings
 
 __version__ = '2.1.0'
 
-app_settings = Settings()
+default_app_config = 'wagtailmenus.apps.WagtailMenusConfig'
+app_settings = None
+
+
+def initialize_settings():
+    global app_settings
+    from .app_settings import Settings
+    app_settings = Settings()
 
 
 def get_main_menu_model_string():

--- a/wagtailmenus/__init__.py
+++ b/wagtailmenus/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import, unicode_literals
-from django.core.exceptions import ImproperlyConfigured
 from .app_settings import Settings
 
 __version__ = '2.1.0'
@@ -35,6 +34,8 @@ def get_main_menu_model():
     if no custom model is defined.
     """
     from django.apps import apps
+    from django.core.exceptions import ImproperlyConfigured
+
     model_string = get_main_menu_model_string()
     try:
         return apps.get_model(model_string)
@@ -57,6 +58,8 @@ def get_flat_menu_model():
     if no custom model is defined.
     """
     from django.apps import apps
+    from django.core.exceptions import ImproperlyConfigured
+
     model_string = get_flat_menu_model_string()
     try:
         return apps.get_model(model_string)

--- a/wagtailmenus/apps.py
+++ b/wagtailmenus/apps.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.apps import AppConfig
+from . import initialize_settings
+
+
+class WagtailMenusConfig(AppConfig):
+    name = 'wagtailmenus'
+    verbose_name = 'WagtailMenus'
+
+    def __init__(self, app_name, app_module):
+        super(WagtailMenusConfig, self).__init__(app_name, app_module)
+        initialize_settings()


### PR DESCRIPTION
Using AppConfig to properly initialize the global var app_settings, so we don't do imports when a `pip install` loads `__init__.py` to read the `__version__` string. 

Fix for https://github.com/rkhleics/wagtailmenus/issues/93