### PR TITLE
Make it easier to use MenuPage fields and methods when already subclassing a Page model

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Installing wagtailmenus
 	
     ```
 	
-5. Run `python manage.py migrate wagtailmenus` to set up the initial database tables.
+5. Run `python manage.py migrate wagtailmenus` to create the necessary database tables.
 
 
 Making use of `MenuPage`
@@ -92,8 +92,10 @@ While wagtailmenus' menu tags will work with your existing page tree and page ty
 
 1. Import `MenuPage` in your `models.py` file like so: `from wagtailmenus.models import MenuPage` 
 2. For any page-types that you'd like to become `MenuPage` pages, simply subclass `MenuPage` instead of `wagtail.wagtailcore.models.Page`.
-2. Run `python manage.py makemigrations` to create migrations for the apps you've updated.
-3. Run `python manage.py migrate` to apply the migrations.
+3. Run `python manage.py makemigrations` to create migrations for the apps you've updated.
+4. Run `python manage.py migrate` to apply the migrations.
+
+If for some reason subclassing `MenuPage` won't work (perhaps you need to subclass another model based on `Page`, such as wagtail's `AbstractForm` and `AbstractEmailForm` models), you can import and use `wagtailmenus.models.MenuPageMixin` instead to gain the same fields and functionality. However, you will need to override `settings_panels` on your model yourself to surface the fields in the page editor interface.
 
 
 Using wagtailmenus

--- a/wagtailmenus/models/__init__.py
+++ b/wagtailmenus/models/__init__.py
@@ -1,10 +1,3 @@
-from .pages import MenuPage
-from .menus import (
-    Menu, MenuFromRootPage, MenuWithMenuItems,
-    AbstractMainMenu, AbstractFlatMenu,
-    MainMenu, FlatMenu
-)
-from .menuitems import (
-    MenuItem, AbstractMenuItem, AbstractMainMenuItem, AbstractFlatMenuItem,
-    MainMenuItem, FlatMenuItem
-)
+from .pages import *  # noqa
+from .menus import *  # noqa
+from .menuitems import *  # noqa

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -11,7 +11,7 @@ from .. import app_settings
 from ..panels import menupage_settings_panels
 
 
-class MenuPage(Page):
+class MenuPageMixin(models.Model):
     repeat_in_subnav = models.BooleanField(
         verbose_name=_("repeat in sub-navigation"),
         default=False,
@@ -29,8 +29,6 @@ class MenuPage(Page):
             "will be used."
         )
     )
-
-    settings_panels = menupage_settings_panels
 
     class Meta:
         abstract = True
@@ -92,3 +90,11 @@ class MenuPage(Page):
             active_class = app_settings.ACTIVE_CLASS
         setattr(menuitem, 'active_class', active_class)
         return menuitem
+
+
+class MenuPage(Page, MenuPageMixin):
+
+    settings_panels = menupage_settings_panels
+
+    class Meta:
+        abstract = True


### PR DESCRIPTION
Move all with fields and methods from `MenuPage` to a new abstract `MenuPageMixin` model, which can be used in cases where `MenuPage` cannot be used.