### PR TITLE
Use default site in context_processors if request.site hasn't been set

### DIFF
--- a/wagtailmenus/context_processors.py
+++ b/wagtailmenus/context_processors.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.http import Http404
 from django.utils.functional import SimpleLazyObject
 from . import app_settings
+from .utils.misc import get_site_from_request
 
 
 def wagtailmenus(request):
@@ -13,7 +14,7 @@ def wagtailmenus(request):
         ancestor_ids = request.META.get(
             'WAGTAILMENUS_CURRENT_PAGE_ANCESTOR_IDS')
         match = None
-        site = request.site
+        site = get_site_from_request(request, fallback_to_default=True)
 
         guess_pos = app_settings.GUESS_TREE_POSITION_FROM_PATH
         sroot_depth = app_settings.SECTION_ROOT_DEPTH

--- a/wagtailmenus/utils/misc.py
+++ b/wagtailmenus/utils/misc.py
@@ -7,11 +7,7 @@ def get_attrs_from_context(context, guess_tree_position=True):
     Gets a bunch of useful things from the context/request and returns them as
     a tuple for use in most menu tags.
     """
-    try:
-        request = context['request']
-    except KeyError:
-        request = None
-
+    request = context.get('request')
     site = get_site_from_request(request)
     wagtailmenus_vals = context.get('wagtailmenus_vals')
     current_page = wagtailmenus_vals.get('current_page')
@@ -21,11 +17,10 @@ def get_attrs_from_context(context, guess_tree_position=True):
 
 
 def get_site_from_request(request, fallback_to_default=True):
-    try:
+    if getattr(request, 'site', None):
         return request.site
-    except AttributeError:
-        if fallback_to_default:
-            return Site.objects.filter(is_default_site=True).first()
+    if fallback_to_default:
+        return Site.objects.filter(is_default_site=True).first()
     return None
 
 

--- a/wagtailmenus/utils/template.py
+++ b/wagtailmenus/utils/template.py
@@ -6,7 +6,7 @@ def get_template_names(menu_tag, request, override):
     if override:
         return [override]
     template_names = []
-    site = get_site_from_request(request)
+    site = get_site_from_request(request, fallback_to_default=True)
     if app_settings.SITE_SPECIFIC_TEMPLATE_DIRS and site:
         hostname = site.hostname
         template_names.extend([


### PR DESCRIPTION
- Minor code tidying in utils.misc
- Make context_processors.wagtailmenus use a default site when site isn’t populated on request