### PR TITLE
Support for Wagtail 1.10 and Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   include:
   - env: TOXENV=py27-dj18-wt15
     python: 2.7
-  - env: TOXENV=py33-dj18-wt15
-    python: 3.3
   - env: TOXENV=py34-dj18-wt15
     python: 3.4
   - env: TOXENV=py35-dj110-wt16

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,17 @@ matrix:
     python: 2.7
   - env: TOXENV=py33-dj18-wt15
     python: 3.3
-  - env: TOXENV=py35-dj19-wt15
-    python: 3.5  
+  - env: TOXENV=py34-dj18-wt15
+    python: 3.4
   - env: TOXENV=py35-dj110-wt16
     python: 3.5
   - env: TOXENV=py35-dj110-wt17
-    python: 3.5 
+    python: 3.6 
   - env: TOXENV=py35-dj110-wt18
-    python: 3.5 
+    python: 3.6 
   - env: TOXENV=py36-dj110-wt19
+    python: 3.6 
+  - env: TOXENV=py36-dj111-wt110
     python: 3.6 
 install:
 - pip install tox coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,16 @@ matrix:
   include:
   - env: TOXENV=py27-dj18-wt15
     python: 2.7
-  - env: TOXENV=py34-dj18-wt15
-    python: 3.4
+  - env: TOXENV=py33-dj18-wt15
+    python: 3.3
+  - env: TOXENV=py35-dj19-wt15
+    python: 3.5  
   - env: TOXENV=py35-dj110-wt16
     python: 3.5
   - env: TOXENV=py35-dj110-wt17
-    python: 3.6 
+    python: 3.5 
   - env: TOXENV=py35-dj110-wt18
-    python: 3.6 
+    python: 3.5 
   - env: TOXENV=py36-dj110-wt19
     python: 3.6 
   - env: TOXENV=py36-dj111-wt110

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ What is wagtailmenus?
 
 It's an extension for Torchbox's [Wagtail CMS](https://github.com/torchbox/wagtail) to help you manage and render multi-level navigation and simple flat menus in a consistent, flexible way.
 
-The current version is compatible with Wagtail 1.5 to 1.9, and Python 2.7, 3.3, 3.4 and 3.5.
+The current version is compatible with Wagtail 1.5 to 1.10 and Python 2.7, 3.3, 3.4, 3.5 and 3.6
 
 What does it do?
 ================

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,4 @@
-wagtail>=1.9,<1.10
+wagtail>=1.10,<1.11
 beautifulsoup4>=4.4.1,<4.5.0
 django-debug-toolbar
 django-extensions

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,7 @@ skipsdist = True
 usedevelop = True
 
 envlist = 
-    py{27,34,35}-dj{19,110}-wt{15,16,17,18,19}
-    py{27,33,34,35,36}-dj18-wt15
+    py{27,34,35,36}-dj{18,19,110,111}-wt{15,16,17,18,19,110}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -12,7 +11,6 @@ commands = coverage run --source=wagtailmenus runtests.py
 
 basepython =
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -21,8 +19,10 @@ deps =
     dj18: Django>=1.8.1,<1.9
     dj19: Django>=1.9,<1.10
     dj110: Django>=1.10a1,<1.11
+    dj111: Django>=1.11,<1.12
     wt15: wagtail>=1.5.1,<1.6
     wt16: wagtail>=1.6,<1.7
     wt17: wagtail>=1.7,<1.8
     wt18: wagtail>=1.8,<1.9
     wt19: wagtail>=1.9,<1.10
+    wt10: wagtail>=1.10,<1.11

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = True
 
 envlist = 
-    py{27,34,35,36}-dj{18,19,110,111}-wt{15,16,17,18,19,110}
+    py{27,33,34,35,36}-dj{18,19,110,111}-wt{15,16,17,18,19,110}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -11,6 +11,7 @@ commands = coverage run --source=wagtailmenus runtests.py
 
 basepython =
     py27: python2.7
+    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6
@@ -26,3 +27,4 @@ deps =
     wt18: wagtail>=1.8,<1.9
     wt19: wagtail>=1.9,<1.10
     wt110: wagtail>=1.10,<1.11
+    wt111: wagtail>=1.11,<1.12

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ deps =
     wt17: wagtail>=1.7,<1.8
     wt18: wagtail>=1.8,<1.9
     wt19: wagtail>=1.9,<1.10
-    wt10: wagtail>=1.10,<1.11
+    wt110: wagtail>=1.10,<1.11


### PR DESCRIPTION
Tests pass without any changes needed, and no warnings triggered - so this essentially just adds a new environment test to the Travis config to ensure support is maintained.