### PR TITLE
Fix for: #123 Error not visible when missing both link page and link url

### DIFF
--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -115,10 +115,11 @@ class AbstractMenuItem(models.Model, MenuItem):
             })
 
         if self.link_url and self.link_page:
-            raise ValidationError(_(
-                "You cannot link to both a page and URL. Please review your "
-                "link and clear any unwanted values."
-            ))
+            msg = _('A menu item cannot link to both a page and a custom URL.')
+            raise ValidationError({
+                'link_page': [msg],
+                'link_url': [msg],
+            })
 
     def __str__(self):
         return self.menu_text

--- a/wagtailmenus/tests/test_models.py
+++ b/wagtailmenus/tests/test_models.py
@@ -35,7 +35,7 @@ class TestModels(TestCase):
             link_page=Page.objects.get(pk=6))
         self.assertRaisesMessage(
             ValidationError,
-            "You cannot link to both a page and URL. Please review your link and clear any unwanted values.",
+            "A menu item cannot link to both a page and a custom URL.",
             new_item.clean)
 
     def test_mainmenuitem_str(self):


### PR DESCRIPTION
Fixes #123. 

Since wagtail is still in the process of making updates to support non-field errors, and there's no telling if the recent changes apply to InlinePanel model errors too, I thought it made sense to just raise field errors instead.