### PR TITLE
Fix try/except logic for calling modify_submenu_items and has_submenu_items with/without request

### DIFF
--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -202,14 +202,14 @@ def get_sub_menu_items_for_page(
         try:
             menu_items = page.modify_submenu_items(*args)
         except TypeError:
+            args.pop()  # try without 'request' arg
+            menu_items = page.modify_submenu_items(*args)
             warning_msg = (
                 "The '%s' model's 'modify_submenu_items' method should be "
                 "updated to accept a 'request' argument"
                 % page.__class__.__name__
             )
             warnings.warn(warning_msg)
-        args.pop()  # try without 'request' arg
-        menu_items = page.modify_submenu_items(*args)
 
     return page, menu_items
 
@@ -522,15 +522,14 @@ def prime_menu_items(
                     try:
                         has_children_in_menu = page.has_submenu_items(*args)
                     except TypeError:
+                        args.pop()  # try without 'request' arg
+                        has_children_in_menu = page.has_submenu_items(*args)
                         warning_msg = (
                             "The '%s' model's 'has_submenu_items' method "
                             "should be updated to accept a 'request' argument"
                             % page.__class__.__name__
                         )
                         warnings.warn(warning_msg)
-                    args.pop()  # try without 'request' arg
-                    has_children_in_menu = page.has_submenu_items(*args)
-
                 else:
                     has_children_in_menu = menu_instance.page_has_children(
                         page)

--- a/wagtailmenus/tests/models/pages.py
+++ b/wagtailmenus/tests/models/pages.py
@@ -43,28 +43,28 @@ class MultilingualMenuPage(MenuPage):
     def modify_submenu_items(
         self, menu_items, current_page, current_ancestor_ids,
         current_site, allow_repeating_parents, apply_active_classes,
-        original_menu_tag, menu_instance=None
+        original_menu_tag, menu_instance, request
     ):
         return super(MultilingualMenuPage, self).modify_submenu_items(
             menu_items, current_page, current_ancestor_ids,
             current_site, allow_repeating_parents, apply_active_classes,
-            original_menu_tag, menu_instance)
+            original_menu_tag, menu_instance, request)
 
     def has_submenu_items(
         self, current_page, allow_repeating_parents, original_menu_tag,
-        menu_instance=None
+        menu_instance, request
     ):
         return super(MultilingualMenuPage, self).has_submenu_items(
             current_page, allow_repeating_parents, original_menu_tag,
-            menu_instance)
+            menu_instance, request)
 
     def get_repeated_menu_item(
         self, current_page, current_site, apply_active_classes,
-        original_menu_tag
+        original_menu_tag, request
     ):
         item = super(MultilingualMenuPage, self).get_repeated_menu_item(
             current_page, current_site, apply_active_classes,
-            original_menu_tag)
+            original_menu_tag, request)
         item.text = self.translated_repeated_item_text or self.translated_title
         return item
 
@@ -111,7 +111,7 @@ class ContactPage(MenuPage):
     def modify_submenu_items(
         self, menu_items, current_page, current_ancestor_ids,
         current_site, allow_repeating_parents, apply_active_classes,
-        original_menu_tag, menu_instance
+        original_menu_tag, menu_instance, request
     ):
         menu_items = super(ContactPage, self).modify_submenu_items(
             menu_items, current_page, current_ancestor_ids,
@@ -144,7 +144,7 @@ class ContactPage(MenuPage):
 
     def has_submenu_items(
         self, current_page, allow_repeating_parents,
-        original_menu_tag, menu_instance
+        original_menu_tag, menu_instance, request
     ):
         """
         Because `modify_submenu_items` is being used to add additional menu
@@ -156,4 +156,4 @@ class ContactPage(MenuPage):
             return True
         return super(ContactPage, self).has_submenu_items(
             current_page, allow_repeating_parents, original_menu_tag,
-            menu_instance)
+            menu_instance, request)


### PR DESCRIPTION
Corrects an issue introduced by PR #121.

If `has_submenu_items` or `modify_submenu_items` do accept a `request` parameter, we don't try again without it: The 2nd attempt needs to happen within the `except` block, not after. 

Also updates the test models so that the warning is no longer given when running tests