### PR TITLE
Fix: Implement a better solution for deprecation errors

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,15 +1,51 @@
 #!/usr/bin/env python
+import argparse
 import os
 import sys
+import warnings
 
-import django
-from django.conf import settings
-from django.test.utils import get_runner
+from django.core.management import execute_from_command_line
 
-if __name__ == "__main__":
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtailmenus.settings.testing'
-    django.setup()
-    TestRunner = get_runner(settings)
-    test_runner = TestRunner()
-    failures = test_runner.run_tests(["wagtailmenus"])
-    sys.exit(bool(failures))
+os.environ['DJANGO_SETTINGS_MODULE'] = 'wagtailmenus.settings.testing'
+
+
+def make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--deprecation',
+        choices=['all', 'pending', 'imminent', 'none'],
+        default='imminent'
+    )
+    return parser
+
+
+def parse_args(args=None):
+    return make_parser().parse_args(args)
+
+
+def runtests():
+    args = parse_args()
+
+    if args.deprecation == 'all':
+        # Show all deprecation warnings from all packages
+        warnings.simplefilter('default', category=DeprecationWarning)
+        warnings.simplefilter('default', category=PendingDeprecationWarning)
+    elif args.deprecation == 'pending':
+        # Show all deprecation warnings
+        warnings.filterwarnings('default', category=DeprecationWarning)
+        warnings.filterwarnings('default', category=PendingDeprecationWarning)
+    elif args.deprecation == 'imminent':
+        # Show only imminent deprecation warnings
+        warnings.filterwarnings('default', category=DeprecationWarning)
+    elif args.deprecation == 'none':
+        # Deprecation warnings are ignored by default
+        pass
+
+    argv = [sys.argv[0], 'test']
+    try:
+        execute_from_command_line(argv)
+    except:
+        pass
+
+if __name__ == '__main__':
+    runtests()

--- a/wagtailmenus/tests/models/pages.py
+++ b/wagtailmenus/tests/models/pages.py
@@ -111,7 +111,7 @@ class ContactPage(MenuPage):
     def modify_submenu_items(
         self, menu_items, current_page, current_ancestor_ids,
         current_site, allow_repeating_parents, apply_active_classes,
-        original_menu_tag, menu_instance, request
+        original_menu_tag, menu_instance=None, request=None
     ):
         menu_items = super(ContactPage, self).modify_submenu_items(
             menu_items, current_page, current_ancestor_ids,
@@ -144,7 +144,7 @@ class ContactPage(MenuPage):
 
     def has_submenu_items(
         self, current_page, allow_repeating_parents,
-        original_menu_tag, menu_instance, request
+        original_menu_tag, menu_instance=None, request=None
     ):
         """
         Because `modify_submenu_items` is being used to add additional menu

--- a/wagtailmenus/utils/deprecation.py
+++ b/wagtailmenus/utils/deprecation.py
@@ -1,0 +1,12 @@
+from __future__ import absolute_import, unicode_literals
+
+
+class RemovedInWagtailMenus24Warning(DeprecationWarning):
+    pass
+
+
+removed_in_next_version_warning = RemovedInWagtailMenus24Warning
+
+
+class RemovedInWagtailMenus25Warning(PendingDeprecationWarning):
+    pass

--- a/wagtailmenus/utils/inspection.py
+++ b/wagtailmenus/utils/inspection.py
@@ -1,0 +1,27 @@
+import inspect
+import sys
+
+"""
+This method below was copied from wagtail.wagtailcore.utils (v1.11) and allows
+us to handle deprecation of method arguments in a way that doesn't swallow
+`TypeError` exceptions raised further down the chain. Thank you @gasman!
+"""
+
+
+def accepts_kwarg(func, kwarg):
+    """
+    Determine whether the callable `func` has a signature that accepts the
+    keyword argument `kwarg`
+    """
+    if sys.version_info >= (3, 3):
+        signature = inspect.signature(func)
+        try:
+            signature.bind_partial(**{kwarg: None})
+            return True
+        except TypeError:
+            return False
+    else:
+        # Fall back on inspect.getargspec, available on Python 2.7 but
+        # deprecated since 3.5
+        argspec = inspect.getargspec(func)
+        return (kwarg in argspec.args) or (argspec.keywords is not None)


### PR DESCRIPTION
Fixes #131

As well as the problem outlined in the above issue, using TypeError in a try/except isn't acceptable, as it incorrectly swallows TypeError exceptions raised elsewhere.

Changes include:

- Modifies ‘runtests’ to accept a ‘deprecation’ argument that can be used to optionally surface deprecation warnings in tests
- Adds some wagtailmenus-specific deprecation warnings to wagtailmenus.utils.deprecation to be used within the project
- Adds `wagtailmenus.utils.inspection` with the `accepts_kwarg()` method to help with the current method argument deprecation situation
- Use internal deprecation warning classes and ‘accepts_kwargs’ to the deprecation stuff currently in place for handling the addition of the `request` keyword to several methods