### PR TITLE
Wagtail 1.11 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     python: 3.6 
   - env: TOXENV=py36-dj111-wt110
     python: 3.6 
+  - env: TOXENV=py36-dj111-wt111
+    python: 3.6 
 install:
 - pip install tox coveralls
 script:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 It's an extension for Torchbox's [Wagtail CMS](https://github.com/torchbox/wagtail) to help you manage and render multi-level navigation and simple flat menus in a consistent, flexible way.
 
-The current version is compatible with Wagtail 1.5 to 1.10 and Python 2.7, 3.3, 3.4, 3.5 and 3.6
+The current version is compatible with Wagtail 1.5 to 1.11 and Python 2.7, 3.3, 3.4, 3.5 and 3.6
 
 # What does it do?
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,4 @@
-wagtail>=1.10,<1.11
+wagtail>=1.11,<1.12
 beautifulsoup4>=4.4.1,<4.5.0
 django-debug-toolbar
 django-extensions

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = True
 
 envlist = 
-    py{27,33,34,35,36}-dj{18,19,110,111}-wt{15,16,17,18,19,110}
+    py{27,33,34,35,36}-dj{18,19,110,111}-wt{15,16,17,18,19,110,111}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}


### PR DESCRIPTION
- Test configuration tweaks to test against Wagtail 1.11 and Django 1.11
- Update development requirements for easier manual testing
- No other changes needed (no compatibility issues found)