### PR TITLE
Always set 'has_children_in_menu=False' on repeated menu items by default

### DIFF
--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -115,7 +115,7 @@ class MenuPageMixin(models.Model):
         """
         return menu_instance.page_has_children(self)
 
-    def get_text_for_repeated_item(
+    def get_text_for_repeated_menu_item(
         self, request=None, current_site=None, original_menu_tag='', **kwargs
     ):
         """Return the a string to use as 'text' for this page when it is being
@@ -137,7 +137,7 @@ class MenuPageMixin(models.Model):
         menuitem = copy(self)
 
         # Set/reset 'text'
-        menuitem.text = self.get_text_for_repeated_item(
+        menuitem.text = self.get_text_for_repeated_menu_item(
             request, current_site, original_menu_tag
         )
 

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -12,7 +12,9 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.wagtailcore.models import Page
 
 from wagtailmenus.utils.inspection import accepts_kwarg
-from wagtailmenus.utils.deprecation import RemovedInWagtailMenus25Warning, RemovedInWagtailMenus26Warning
+from wagtailmenus.utils.deprecation import (
+    RemovedInWagtailMenus25Warning, RemovedInWagtailMenus26Warning
+)
 from .. import app_settings
 from ..forms import LinkPageAdminForm
 from ..panels import menupage_settings_panels, linkpage_edit_handler
@@ -61,14 +63,14 @@ class MenuPageMixin(models.Model):
             """
 
             # Create dict of kwargs to send to `get_repeated_menu_item`
-            method_kwargs = {
+            kwargs = {
                 'current_page': current_page,
                 'current_site': current_site,
                 'apply_active_classes': apply_active_classes,
                 'original_menu_tag': original_menu_tag,
             }
             if accepts_kwarg(self.get_repeated_menu_item, 'request'):
-                method_kwargs['request'] = request
+                kwargs['request'] = request
             else:
                 msg = (
                     "The 'get_repeated_menu_item' method on '%s' should be "
@@ -79,20 +81,22 @@ class MenuPageMixin(models.Model):
                 )
                 warnings.warn(msg, RemovedInWagtailMenus25Warning)
 
-            if accepts_kwarg(self.get_repeated_menu_item, 'use_absolute_page_urls'):
-                method_kwargs['use_absolute_page_urls'] = use_absolute_page_urls
+            if accepts_kwarg(
+                self.get_repeated_menu_item, 'use_absolute_page_urls'
+            ):
+                kwargs['use_absolute_page_urls'] = use_absolute_page_urls
             else:
                 msg = (
                     "The 'get_repeated_menu_item' method on '%s' should be "
-                    "updated to accept a 'use_absolute_page_urls' keyword argument. View the "
-                    "2.4 release notes for more info: https://github.com/"
-                    "rkhleics/wagtailmenus/releases/tag/v.2.4.0" %
-                    self.__class__.__name__
+                    "updated to accept a 'use_absolute_page_urls' keyword "
+                    "argument. View the 2.4 release notes for more info: "
+                    "https://github.com/rkhleics/wagtailmenus/releases/tag/"
+                    "v.2.4.0" % self.__class__.__name__
                 )
                 warnings.warn(msg, RemovedInWagtailMenus26Warning)
 
             # Call `get_repeated_menu_item` using the above kwargs dict
-            repeated_item = self.get_repeated_menu_item(**method_kwargs)
+            repeated_item = self.get_repeated_menu_item(**kwargs)
             menu_items.insert(0, repeated_item)
         return menu_items
 


### PR DESCRIPTION
Should fix #152 

In addition to the above, also this PR also does the following:

- Adds better code commenting to the method to help explain what's
- Abstract out the logic to identify text to use for a 'repeated menu item' to a new 'get_text_for_repeated_item' method to make it more convenient to override, and also to respect the `WAGTAILMENUS_PAGE_FIELD_FOR_MENU_ITEM_TEXT` setting instead of just defaulting to the page title
- Minor code tidying (Flake 8 bit)