### PR TITLE
Meta classes defined in AbstractMainMenuItem and AbstractFlatMenuItem…

### DIFF
--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -79,6 +79,7 @@ class AbstractMenuItem(models.Model, MenuItem):
         abstract = True
         verbose_name = _("menu item")
         verbose_name_plural = _("menu items")
+        ordering = ('sort_order',)
 
     @property
     def menu_text(self):
@@ -151,9 +152,8 @@ class AbstractMainMenuItem(Orderable, AbstractMenuItem):
         )
     )
 
-    class Meta:
+    class Meta(AbstractMenuItem.Meta):
         abstract = True
-        ordering = ('sort_order',)
 
 
 class AbstractFlatMenuItem(Orderable, AbstractMenuItem):
@@ -168,9 +168,8 @@ class AbstractFlatMenuItem(Orderable, AbstractMenuItem):
         )
     )
 
-    class Meta:
+    class Meta(AbstractMenuItem.Meta):
         abstract = True
-        ordering = ('sort_order',)
 
 
 #########################################################

--- a/wagtailmenus/tests/test_models.py
+++ b/wagtailmenus/tests/test_models.py
@@ -6,13 +6,25 @@ from django.test import TestCase
 from django.core.exceptions import ValidationError
 
 from wagtail.wagtailcore.models import Page, Site
-from wagtailmenus.models import MainMenu, MainMenuItem, FlatMenu
+from wagtailmenus.models import MainMenu, MainMenuItem, FlatMenu, FlatMenuItem
 from wagtailmenus.tests.models import LinkPage, NoAbsoluteUrlsPage
 from wagtailmenus.utils.deprecation import RemovedInWagtailMenus26Warning
 
 
 class TestModels(TestCase):
     fixtures = ['test.json']
+
+    def text_mainmenuitem_meta_settings(self):
+        opts = MainMenuItem._meta
+        self.assertEqual(opts.verbose_name, 'menu item')
+        self.assertEqual(opts.verbose_name_plural, 'menu items')
+        self.assertEqual(opts.ordering, ('sort_order',))
+
+    def text_flatmenuitem_meta_settings(self):
+        opts = FlatMenuItem._meta
+        self.assertEqual(opts.verbose_name, 'menu item')
+        self.assertEqual(opts.verbose_name_plural, 'menu items')
+        self.assertEqual(opts.ordering, ('sort_order',))
 
     def test_mainmenuitem_clean_missing_link_text(self):
         menu = MainMenu.objects.get(pk=1)


### PR DESCRIPTION
Meta classes defined on `AbstractMainMenuItem` and `AbstractFlatMenuItenu` models shouldn't repeat values. Common behaviour should be defined once on `AbstractMenuItem`.

This makes the Meta classes on those models subclass the one defined on `AbstractMenuItem`, so that attributes are inherited properly, and adds test to ensure that the _meta info on `MainMenuItem` and `FlatMenuItem` is set appropriately / as expected. 