### PR TITLE
Housekeeping to start work on Wagtailmenus 2.50

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,6 +9,7 @@
 * Adrian Tijsseling (adriaant)
 * Tim Leguijt (tleguijt)
 * Trent Holiday (trumpet2012)
+* Tom Dyson (tomdyson)
 
 
 ## Translators

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -48,7 +48,7 @@ As well as giving you control over your 'main menu', wagtailmenus allows you to 
 Don't hard-code another menu again! CMS-managed menus allow you to make those 'emergency changes' and 'last-minute tweaks' without having to touch a single line of code.
 
 .. NOTE::
-    Despite the name, 'flat menus' can be configured to render as a multi-level menus if you need them to.
+    Despite the name, 'flat menus' can be configured to render as multi-level menus if you need them to.
 
 
 Suitable for single-site or multi-site projects

--- a/docs/source/releases/2.5.0a.rst
+++ b/docs/source/releases/2.5.0a.rst
@@ -1,0 +1,22 @@
+=================================
+Wagtailmenus 2.5.0a release notes
+=================================
+
+.. NOTE::
+    This version is still under development
+
+.. contents::
+    :local:
+    :depth: 2
+
+
+What's new?
+===========
+
+
+Other minor changes
+===================
+
+
+Upgrade considerations
+======================

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -5,6 +5,7 @@ Release notes
 .. toctree::
     :maxdepth: 1
 
+    2.5.0a
     2.4.0
     2.3.2
     2.3.1

--- a/wagtailmenus/__init__.py
+++ b/wagtailmenus/__init__.py
@@ -3,7 +3,7 @@ from wagtailmenus.utils.version import get_version, get_stable_branch_name
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (2, 4, 0, 'final', 0)
+VERSION = (2, 5, 0, 'alpha', 0)
 __version__ = get_version(VERSION)
 stable_branch_name = get_stable_branch_name(VERSION)
 

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -12,9 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from wagtail.wagtailcore.models import Page
 
 from wagtailmenus.utils.inspection import accepts_kwarg
-from wagtailmenus.utils.deprecation import (
-    RemovedInWagtailMenus25Warning, RemovedInWagtailMenus26Warning
-)
+from wagtailmenus.utils.deprecation import RemovedInWagtailMenus26Warning
 from .. import app_settings
 from ..forms import LinkPageAdminForm
 from ..panels import menupage_settings_panels, linkpage_edit_handler
@@ -68,19 +66,8 @@ class MenuPageMixin(models.Model):
                 'current_site': current_site,
                 'apply_active_classes': apply_active_classes,
                 'original_menu_tag': original_menu_tag,
+                'request': request,
             }
-            if accepts_kwarg(self.get_repeated_menu_item, 'request'):
-                kwargs['request'] = request
-            else:
-                msg = (
-                    "The 'get_repeated_menu_item' method on '%s' should be "
-                    "updated to accept a 'request' keyword argument. View the "
-                    "2.3 release notes for more info: https://github.com/"
-                    "rkhleics/wagtailmenus/releases/tag/v.2.3.0" %
-                    self.__class__.__name__
-                )
-                warnings.warn(msg, RemovedInWagtailMenus25Warning)
-
             if accepts_kwarg(
                 self.get_repeated_menu_item, 'use_absolute_page_urls'
             ):

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -6,7 +6,7 @@ from django.template import Library
 from wagtail.wagtailcore.models import Page
 
 from wagtailmenus import app_settings
-from wagtailmenus.utils.deprecation import RemovedInWagtailMenus25Warning, RemovedInWagtailMenus26Warning
+from wagtailmenus.utils.deprecation import RemovedInWagtailMenus26Warning
 from wagtailmenus.utils.inspection import accepts_kwarg
 from wagtailmenus.utils.misc import (
     get_attrs_from_context, validate_supplied_values
@@ -166,7 +166,8 @@ def flat_menu(
 def get_sub_menu_items_for_page(
     request, page, current_site, current_page, ancestor_ids, menu_instance,
     use_specific, apply_active_classes, allow_repeating_parents,
-    current_level=1, max_levels=2, original_menu_tag='', use_absolute_page_urls=False,
+    current_level=1, max_levels=2, original_menu_tag='',
+    use_absolute_page_urls=False,
 ):
     # The menu items will be the children of the provided `page`
     children_pages = menu_instance.get_children_for_page(page)
@@ -213,26 +214,17 @@ def get_sub_menu_items_for_page(
             'apply_active_classes': apply_active_classes,
             'original_menu_tag': original_menu_tag,
             'menu_instance': menu_instance,
+            'request': request,
         }
-        if accepts_kwarg(page.modify_submenu_items, 'request'):
-            method_kwargs['request'] = request
-        else:
-            warning_msg = (
-                "The 'modify_submenu_items' method on '%s' should be "
-                "updated to accept a 'request' keyword argument. View the "
-                "2.3 release notes for more info: https://github.com/rkhleics/"
-                "wagtailmenus/releases/tag/v.2.3.0" % page.__class__.__name__,
-            )
-            warnings.warn(warning_msg, RemovedInWagtailMenus25Warning)
-
         if accepts_kwarg(page.modify_submenu_items, 'use_absolute_page_urls'):
             method_kwargs['use_absolute_page_urls'] = use_absolute_page_urls
         else:
             warning_msg = (
                 "The 'modify_submenu_items' method on '%s' should be "
-                "updated to accept a 'use_absolute_page_urls' keyword argument. View the "
-                "2.4 release notes for more info: https://github.com/rkhleics/"
-                "wagtailmenus/releases/tag/v.2.4.0" % page.__class__.__name__,
+                "updated to accept a 'use_absolute_page_urls' keyword "
+                "argument. View the 2.4 release notes for more info: "
+                "https://github.com/rkhleics/wagtailmenus/releases/tag/v.2.4.0"
+                % page.__class__.__name__,
             )
             warnings.warn(warning_msg, RemovedInWagtailMenus26Warning)
 
@@ -504,7 +496,8 @@ def children_menu(
 def prime_menu_items(
     request, menu_items, current_site, current_page, current_page_ancestor_ids,
     use_specific, original_menu_tag, menu_instance, check_for_children=False,
-    allow_repeating_parents=True, apply_active_classes=True, use_absolute_page_urls=False,
+    allow_repeating_parents=True, apply_active_classes=True,
+    use_absolute_page_urls=False,
 ):
     """
     Prepare a list of `MenuItem` or `Page` objects for rendering to a menu
@@ -587,21 +580,8 @@ def prime_menu_items(
                         'allow_repeating_parents': allow_repeating_parents,
                         'original_menu_tag': original_menu_tag,
                         'menu_instance': menu_instance,
+                        'request': request,
                     }
-                    if accepts_kwarg(page.has_submenu_items, 'request'):
-                        method_kwargs['request'] = request
-                    else:
-                        warning_msg = (
-                            "The 'has_submenu_items' method on '%s' should be "
-                            "updated to accept a 'request' keyword "
-                            "argument. View the 2.3 release notes for more "
-                            "info: https://github.com/rkhleics/wagtailmenus/"
-                            "releases/tag/v.2.3.0" % page.__class__.__name__
-                        )
-                        warnings.warn(
-                            warning_msg, RemovedInWagtailMenus25Warning
-                        )
-
                     # Call `has_submenu_items` using the above kwargs dict
                     has_children_in_menu = page.has_submenu_items(
                         **method_kwargs)

--- a/wagtailmenus/utils/deprecation.py
+++ b/wagtailmenus/utils/deprecation.py
@@ -1,16 +1,16 @@
 from __future__ import absolute_import, unicode_literals
 
 
-class RemovedInWagtailMenus25Warning(DeprecationWarning):
+class RemovedInWagtailMenus26Warning(DeprecationWarning):
     pass
 
 
-removed_in_next_version_warning = RemovedInWagtailMenus25Warning
-
-
-class RemovedInWagtailMenus26Warning(PendingDeprecationWarning):
-    pass
+removed_in_next_version_warning = RemovedInWagtailMenus26Warning
 
 
 class RemovedInWagtailMenus27Warning(PendingDeprecationWarning):
+    pass
+
+
+class RemovedInWagtailMenus28Warning(PendingDeprecationWarning):
     pass


### PR DESCRIPTION
- Version bump to 2.5a0
- Remove fallback handling of 'modify_submenu_items' methods with no 'request' kwarg
- Remove fallback handling of 'has_submenu_items' methods with no 'request' kwarg
- Remove fallback handling of 'self.get_repeated_menu_item' methods with no 'request' kwarg
- Rotate deprecation warnings
- Add blank release notes
- Added Tom Dyson to contributors list
- Fixed a type in docs

