### PR TITLE
Tidying up of menu_tags.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,34 @@
 Changelog
 =========
 
-2.X.X (XX.XX.XXXX) IN DEVELOPMENT
---------------------------------- 
+2.5.0a (XX.XX.XXXX) IN DEVELOPMENT
+---------------------------------- 
+
+* Fixed an issue with runtests.py that was causing tox builds in Travis CI
+  to report as successful, even when tests were failing. Contributed by
+  Oliver Bestwalter (obestwalter).
+* Updated signature of `menu_tags.get_sub_menu_items_for_page()` to improve
+  code readability and improve consistency.
+    * Renamed `ancestor_ids` to `current_ancestor_ids`
+    * `original_menu_tag`, `current_level`, and `max_levels` are now required
+    * Arguments order also revised
+* Updated signature of `menu_tags.prime_menu_items()` to improve code
+  readability and consistency, and to support additional arguments required
+  for new hooks functionality.
+    * Renamed `current_page_ancestor_ids` to `current_ancestor_ids`
+    * Added new `parent_page`, `current_level`, and `max_levels` arguments (
+      which are all required)
+    * Removed the `check_for_children` argument, in favour of using
+      'current_level' and 'max_levels'.
+    * Arguments order also revised
+* All calls to `prime_menu_items` are made with arguments in the same order.
+* All calls to `get_sub_menu_items_for_page` are made with arguments in the
+  same order.
+* The `stop_at_this_level` argument for the `sub_menu` tag has been
+  officially deprecated and the feature removed from documentation. It hasn't 
+  worked for a few versions and nobody has mentioned it, so this is the first
+  step to removing it completely.
+
 
 2.4.0 (04.08.2017)
 ------------------ 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@
 * Tim Leguijt (tleguijt)
 * Trent Holiday (trumpet2012)
 * Tom Dyson (tomdyson)
+* Oliver Bestwalter (obestwalter)
 
 
 ## Translators

--- a/docs/source/releases/2.5.0a.rst
+++ b/docs/source/releases/2.5.0a.rst
@@ -7,7 +7,7 @@ Wagtailmenus 2.5.0a release notes
 
 .. contents::
     :local:
-    :depth: 2
+    :depth: 1
 
 
 What's new?
@@ -28,8 +28,24 @@ Now, 'top_level_items' has been refactored to call get_base_page_queryset() to f
 When sourcing data for a main or flat menu, it doesn't make sense to apply two sets of filters relating to pages status/visibility, so 'for_display' now simply returns ALL menu items defined for a menu, and any unsuitable page links are filtered out in a menu instances 'top_level_items' by calling upon 'get_base_page_queryset'.
 
 
-Other minor changes
-===================
+Bug fixes & minor changes 
+=========================
+
+*   Fixed an issue with runtests.py that was causing tox builds in Travis CI
+    to report as successful, even when tests were failing. Contributed by
+    Oliver Bestwalter (obestwalter).
+*   Updated signature of ``menu_tags.get_sub_menu_items_for_page()`` to improve
+    code readability (see below for more details).
+*   Updated signature of ``menu_tags.prime_menu_items()`` to improve code
+    readability and consistency, and to support additional arguments required
+    for new hooks functionality (see below for more details).
+*   All calls to ``prime_menu_items`` are made with arguments in the same order.
+*   All calls to ``get_sub_menu_items_for_page`` are made with arguments in the
+    same order.
+*   The ``stop_at_this_level`` argument for the ``sub_menu`` tag has been
+    officially deprecated and the feature removed from documentation. It hasn't 
+    worked for a few versions and nobody has mentioned it, so this is the first
+    step to removing it completely.
 
 
 Upgrade considerations
@@ -92,3 +108,35 @@ However, if you really do need 'for_display()' to return the same results as it 
             return qs
 
 
+If you're calling ``menu_tags.prime_menu_items()`` directly anywhere 
+--------------------------------------------------------------------
+
+This method is only intended for use by the other methods in ``menu_tags.py``, and shouldn't be used elsewhere. But, if you are calling it directly, it's likely that you will have to update your code to match the methods updated signature.
+
+The method now accepts three new required arguments:
+
+* ``parent_page``: If the calling tag is rendering a sub-menu for children of a given page, you should pass that page object here. Pass ``None`` if no parent page is involved (for example, if rendering the top level of a main or flat menu, where the menu items are defined on each menu)
+* ``current_level``: An integer indicating the 'level' or 'depth' that is currently being rendered in the process of rendering a multi-level menu.
+* ``max_levels``: An integer indicatiing the maxiumum number of levels that should be rendered for the current menu.
+
+The ``check_for_children`` argument is no longer accepted.
+
+The ``current_page_ancestor_ids`` argument has been renamed to ``curren_ancestor_ids``.
+
+The position of arguments has changed considerably too. If calling the method using positional arguments, you should examine the code to ensure you're passing arguments in the correct order.
+
+
+If you're calling ``menu_tags.get_sub_menu_items_for_page()`` directly anywhere
+-------------------------------------------------------------------------------
+
+This method is only intended for use by the other methods in ``menu_tags.py``, and shouldn't be used elsewhere. But, if you are calling it directly, it's likely that you will have to update your code to match the methods updated signature.
+
+The following arguments are now required instead of optional:
+
+* ``original_menu_tag``: The name of the tag that was called to initiate rendering of the menu that is currently being rendered. For example, if you're using the ``main_menu`` tag to render a multi-level menu, even though ``sub_menu`` may be called to render subsequent additional levels, 'original_menu_tag' should retain the value ``'main_menu'``
+* ``current_level``: An integer indicating the 'level' or 'depth' that is currently being rendered in the process of rendering a multi-level menu.
+* ``max_levels``: An integer indicatiing the maxiumum number of levels that should be rendered for the current menu.
+
+The ``ancestor_ids`` argument has been renamed to ``curren_ancestor_ids``.
+
+The position of arguments has changed considerably too. If calling the method using positional arguments, you should examine the code to ensure you're passing arguments in the correct order.

--- a/docs/source/rendering_menus/template_tag_reference.rst
+++ b/docs/source/rendering_menus/template_tag_reference.rst
@@ -688,19 +688,6 @@ item must be passed to ``{% sub_menu %}`` so that it knows which page to render 
 
 -----
 
-stop_at_this_level
-~~~~~~~~~~~~~~~~~~
-
-=========  ===================  ====================================
-Required?  Expected value type  Default value
-=========  ===================  ====================================
-No         ``bool``             ``None`` (inherit from original tag)
-=========  ===================  ====================================
-
-The ``sub_menu`` tag will automatically figure out whether further levels should be rendered or not by comparing the ``max_levels`` value from the original menu tag with the current level being rendered. However, you can override that behaviour by adding either ``stop_at_this_level=True`` or ``stop_at_this_level=False`` to the tag in a custom menu template.
-
------
-
 apply_active_classes
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/rendering_menus/template_tag_reference.rst
+++ b/docs/source/rendering_menus/template_tag_reference.rst
@@ -756,5 +756,3 @@ No         ``bool``             ``None`` (inherit from original tag)
 Allows you to override the value set on the original tag by explicitly adding ``use_absolute_page_urls=True`` or ``use_absolute_page_urls=False`` to a ``{% sub_menu %}`` tag in a custom menu template. 
 
 If ``True``, absolute page URLs will be used for the ``href`` attributes on page links instead of relative URLs.
-
------

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -6,7 +6,8 @@ from django.template import Library
 from wagtail.wagtailcore.models import Page
 
 from wagtailmenus import app_settings
-from wagtailmenus.utils.deprecation import RemovedInWagtailMenus26Warning
+from wagtailmenus.utils.deprecation import (
+    RemovedInWagtailMenus26Warning, RemovedInWagtailMenus27Warning)
 from wagtailmenus.utils.inspection import accepts_kwarg
 from wagtailmenus.utils.misc import (
     get_attrs_from_context, validate_supplied_values
@@ -256,6 +257,15 @@ def sub_menu(
     """
     validate_supplied_values('sub_menu', use_specific=use_specific,
                              menuitem_or_page=menuitem_or_page)
+
+    if stop_at_this_level is not None:
+        warning_msg = (
+            "The 'stop_at_this_level' argument for 'sub_menu' no longer "
+            "has any effect on output and is deprecated. View the 2.5 release "
+            "notes for more info: "
+            "http://wagtailmenus.readthedocs.io/en/stable/releases/2.5.0.html"
+        )
+        warnings.warn(warning_msg, RemovedInWagtailMenus27Warning)
 
     # Variabalise relevant attributes from context
     request, site, current_page, root, ancestor_ids = get_attrs_from_context(

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -47,6 +47,23 @@ def main_menu(
     if use_specific is not None:
         menu.set_use_specific(use_specific)
 
+    menu_items = prime_menu_items(
+        menu_items=menu.top_level_items,
+        request=request,
+        parent_page=None,
+        original_menu_tag='main_menu',
+        menu_instance=menu,
+        current_level=1,
+        max_levels=menu.max_levels,
+        current_site=site,
+        current_page=current_page,
+        current_ancestor_ids=ancestor_ids,
+        use_specific=menu.use_specific,
+        allow_repeating_parents=allow_repeating_parents,
+        apply_active_classes=apply_active_classes,
+        use_absolute_page_urls=use_absolute_page_urls,
+    )
+
     # Identify templates for rendering
     template_names = get_template_names('main', request, template)
     t = context.template.engine.select_template(template_names)
@@ -56,20 +73,7 @@ def main_menu(
 
     c = copy(context)
     c.update({
-        'menu_items': prime_menu_items(
-            request=request,
-            menu_items=menu.top_level_items,
-            current_site=site,
-            current_page=current_page,
-            current_page_ancestor_ids=ancestor_ids,
-            use_specific=menu.use_specific,
-            original_menu_tag='main_menu',
-            menu_instance=menu,
-            check_for_children=menu.max_levels > 1,
-            allow_repeating_parents=allow_repeating_parents,
-            apply_active_classes=apply_active_classes,
-            use_absolute_page_urls=use_absolute_page_urls,
-        ),
+        'menu_items': menu_items,
         'main_menu': menu,
         'use_specific': menu.use_specific,
         'max_levels': menu.max_levels,
@@ -122,6 +126,23 @@ def flat_menu(
     if use_specific is not None:
         menu.set_use_specific(use_specific)
 
+    menu_items = prime_menu_items(
+        menu_items=menu.top_level_items,
+        request=request,
+        parent_page=None,
+        original_menu_tag='flat_menu',
+        menu_instance=menu,
+        current_level=1,
+        max_levels=menu.max_levels,
+        current_site=site,
+        current_page=current_page,
+        current_ancestor_ids=ancestor_ids,
+        use_specific=menu.use_specific,
+        allow_repeating_parents=allow_repeating_parents,
+        apply_active_classes=apply_active_classes,
+        use_absolute_page_urls=use_absolute_page_urls,
+    )
+
     template_names = menu.get_template_names(request, template)
     t = context.template.engine.select_template(template_names)
 
@@ -131,20 +152,7 @@ def flat_menu(
 
     c = copy(context)
     c.update({
-        'menu_items': prime_menu_items(
-            request=request,
-            menu_items=menu.top_level_items,
-            current_site=site,
-            current_page=current_page,
-            current_page_ancestor_ids=ancestor_ids,
-            use_specific=menu.use_specific,
-            original_menu_tag='flat_menu',
-            menu_instance=menu,
-            check_for_children=menu.max_levels > 1,
-            allow_repeating_parents=allow_repeating_parents,
-            apply_active_classes=apply_active_classes,
-            use_absolute_page_urls=use_absolute_page_urls,
-        ),
+        'menu_items': menu_items,
         'matched_menu': menu,
         'menu_handle': handle,
         'menu_heading': menu.heading,
@@ -164,10 +172,10 @@ def flat_menu(
 
 
 def get_sub_menu_items_for_page(
-    request, page, current_site, current_page, ancestor_ids, menu_instance,
-    use_specific, apply_active_classes, allow_repeating_parents,
-    current_level=1, max_levels=2, original_menu_tag='',
-    use_absolute_page_urls=False,
+    page, request, original_menu_tag, menu_instance, current_level, max_levels,
+    current_site, current_page, current_ancestor_ids, use_specific,
+    allow_repeating_parents=True, apply_active_classes=True,
+    use_absolute_page_urls=False
 ):
     # The menu items will be the children of the provided `page`
     children_pages = menu_instance.get_children_for_page(page)
@@ -176,15 +184,17 @@ def get_sub_menu_items_for_page(
     # will add `href`, `text`, `active_class` and `has_children_in_menu`
     # attributes to each item, to use in menu templates.
     menu_items = prime_menu_items(
-        request=request,
         menu_items=children_pages,
-        current_site=current_site,
-        current_page=current_page,
-        current_page_ancestor_ids=ancestor_ids,
-        use_specific=use_specific,
+        request=request,
+        parent_page=page,
         original_menu_tag=original_menu_tag,
         menu_instance=menu_instance,
-        check_for_children=current_level < max_levels,
+        current_level=current_level,
+        max_levels=max_levels,
+        current_site=current_site,
+        current_page=current_page,
+        current_ancestor_ids=current_ancestor_ids,
+        use_specific=use_specific,
         allow_repeating_parents=allow_repeating_parents,
         apply_active_classes=apply_active_classes,
         use_absolute_page_urls=use_absolute_page_urls,
@@ -208,7 +218,7 @@ def get_sub_menu_items_for_page(
         method_kwargs = {
             'menu_items': menu_items,
             'current_page': current_page,
-            'current_ancestor_ids': ancestor_ids,
+            'current_ancestor_ids': current_ancestor_ids,
             'current_site': current_site,
             'allow_repeating_parents': allow_repeating_parents,
             'apply_active_classes': apply_active_classes,
@@ -289,18 +299,18 @@ def sub_menu(
         parent_page = menuitem_or_page.link_page
 
     parent_page, menu_items = get_sub_menu_items_for_page(
-        request=request,
         page=parent_page,
-        current_site=site,
-        current_page=current_page,
-        ancestor_ids=ancestor_ids,
-        menu_instance=menu_instance,
-        use_specific=use_specific,
+        request=request,
         original_menu_tag=original_menu_tag,
+        menu_instance=menu_instance,
         current_level=current_level,
         max_levels=max_levels,
-        apply_active_classes=apply_active_classes,
+        current_site=site,
+        current_page=current_page,
+        current_ancestor_ids=ancestor_ids,
+        use_specific=use_specific,
         allow_repeating_parents=allow_repeating_parents,
+        apply_active_classes=apply_active_classes,
         use_absolute_page_urls=use_absolute_page_urls,
     )
 
@@ -352,18 +362,18 @@ def section_menu(
     menu_instance.set_request(request)
 
     section_root, menu_items = get_sub_menu_items_for_page(
-        request=request,
         page=root,
-        current_site=site,
-        current_page=current_page,
-        ancestor_ids=ancestor_ids,
-        menu_instance=menu_instance,
-        use_specific=use_specific,
+        request=request,
         original_menu_tag='section_menu',
+        menu_instance=menu_instance,
         current_level=1,
         max_levels=max_levels,
-        apply_active_classes=apply_active_classes,
+        current_site=site,
+        current_page=current_page,
+        current_ancestor_ids=ancestor_ids,
+        use_specific=use_specific,
         allow_repeating_parents=allow_repeating_parents,
+        apply_active_classes=apply_active_classes,
         use_absolute_page_urls=use_absolute_page_urls,
     )
 
@@ -454,16 +464,16 @@ def children_menu(
     parent_page, menu_items = get_sub_menu_items_for_page(
         request=request,
         page=parent_page,
-        current_site=site,
-        current_page=current_page,
-        ancestor_ids=ancestor_ids,
-        menu_instance=menu_instance,
-        use_specific=use_specific,
         original_menu_tag='children_menu',
+        menu_instance=menu_instance,
         current_level=1,
         max_levels=max_levels,
-        apply_active_classes=apply_active_classes,
+        current_site=site,
+        current_page=current_page,
+        current_ancestor_ids=ancestor_ids,
+        use_specific=use_specific,
         allow_repeating_parents=allow_repeating_parents,
+        apply_active_classes=apply_active_classes,
         use_absolute_page_urls=use_absolute_page_urls,
     )
 
@@ -494,16 +504,16 @@ def children_menu(
 
 
 def prime_menu_items(
-    request, menu_items, current_site, current_page, current_page_ancestor_ids,
-    use_specific, original_menu_tag, menu_instance, check_for_children=False,
-    allow_repeating_parents=True, apply_active_classes=True,
-    use_absolute_page_urls=False,
+    menu_items, request, parent_page, original_menu_tag, current_level,
+    max_levels, menu_instance, current_site, current_page,
+    current_ancestor_ids, use_specific, allow_repeating_parents=True,
+    apply_active_classes=True, use_absolute_page_urls=False,
 ):
     """
     Prepare a list of `MenuItem` or `Page` objects for rendering to a menu
     template.
     """
-
+    stop_at_this_level = (current_level >= max_levels)
     primed_menu_items = []
 
     for item in menu_items:
@@ -556,7 +566,7 @@ def prime_menu_items(
             """
             has_children_in_menu = False
             if (
-                check_for_children and
+                not stop_at_this_level and
                 page.depth >= app_settings.SECTION_ROOT_DEPTH and
                 (menuitem is None or menuitem.allow_subnav)
             ):
@@ -606,7 +616,7 @@ def prime_menu_items(
                             page = page.specific
                         if getattr(page, 'repeat_in_subnav', False):
                             active_class = app_settings.ACTIVE_ANCESTOR_CLASS
-                elif page.pk in current_page_ancestor_ids:
+                elif page.pk in current_ancestor_ids:
                     active_class = app_settings.ACTIVE_ANCESTOR_CLASS
                 setattr(item, 'active_class', active_class)
 


### PR DESCRIPTION
* Attribute order for `get_sub_menu_items_for_page()` has changed, and the following arguments are now required:
    * original_menu_tag (previously optional)
    * current_level (previously optional)
    * max_levels (previously optional)
* Any code calling`get_sub_menu_items_for_page()` now does so with arguments in a consistent order
* Attribute order for `prime_menu_items()` has changed, and the following new arguments are now required (needed for implementation of hooks):
    * parent_page
    * current_level
    * max_levels
* `prime_menu_items()` no longer accepts the `check_for_children` argument (instead, `current_level` and `max_levels` are used to work out a new `stop_at_this_level` boolean variable)
* Any code calling `prime_menu_items()` always creates a `menu_items` variable, which is then added to the context, and the arguments are always passed in a consistent order