### PR TITLE
Add 'hooks' to allow behaviour to be customised more easiliy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,16 @@ Changelog
     * Removed the `check_for_children` argument, in favour of using
       'current_level' and 'max_levels'.
     * Arguments order also revised
-* All calls to `prime_menu_items` are made with arguments in the same order.
-* All calls to `get_sub_menu_items_for_page` are made with arguments in the
-  same order.
 * The `stop_at_this_level` argument for the `sub_menu` tag has been
   officially deprecated and the feature removed from documentation. It hasn't 
   worked for a few versions and nobody has mentioned it, so this is the first
   step to removing it completely.
+* Reduce code bloat in various methods in `menu_tags.py` by defining common
+  dictionaries of keyword arguments that can be easily passed to different
+  methods.
+* Made the logic in 'pages_for_display' easier to override on custom menu
+  classes by breaking it out into a separate 'get_pages_for_display()' method
+  (that isn't decorated with `cached_property`).
 
 
 2.4.0 (04.08.2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ Changelog
 * Made the logic in 'pages_for_display' easier to override on custom menu
   classes by breaking it out into a separate 'get_pages_for_display()' method
   (that isn't decorated with `cached_property`).
+* Added support for several 'hooks', allowing for easier customisation of base
+  querysets and manipulation of menu items during rendering. For more
+  information and examples, see the 'Hooks' section of the documentation:
+  http://wagtailmenus.readthedocs.io/en/latest/advanced_topics/hooks.html
 
 
 2.4.0 (04.08.2017)

--- a/docs/source/advanced_topics/hooks.rst
+++ b/docs/source/advanced_topics/hooks.rst
@@ -1,0 +1,341 @@
+
+.. _hooks:
+
+=====
+Hooks
+=====
+
+On loading, Wagtail will search for any app with the file ``wagtail_hooks.py`` and execute the contents. This provides a way to register your own functions to execute at certain points in Wagtail's execution, such as when a ``Page`` object is saved or when the main menu is constructed.
+
+Registering functions with a Wagtail hook is done through the ``@hooks.register`` decorator:
+
+.. code-block:: python
+
+  from wagtail.wagtailcore import hooks
+
+  @hooks.register('name_of_hook')
+  def my_hook_function(arg1, arg2...)
+      # your code here
+
+
+Alternatively, ``hooks.register`` can be called as an ordinary function, passing in the name of the hook and a handler function defined elsewhere:
+
+.. code-block:: python
+
+  hooks.register('name_of_hook', my_hook_function)
+
+
+Wagtailmenus utilises this same 'hooks' mechanism to allow you make modifications to menus at certain points during the rendering process.
+
+.. contents::
+    :local:
+    :depth: 2
+
+
+Hooks for modifying data used in menus
+======================================
+
+Menu classes are responsible for fetching all of the data needed for rendering a menu and providing it to template tags as and when it is needed. 
+
+If you need to override a lot of behaviour, and you're comfortable with the idea of subclassing the existing classes and models to override the necessary methods, you might want to look at :ref:`custom_menu_classes`. But, if all you want to do is change the result of ``get_base_page_queryset()`` or ``get_base_menuitem_queryset()`` (say, to limit the links that appear based on the current user), you may find it quicker & easier to use the following hooks instead.
+
+.. _menus_modify_base_page_queryset:
+
+menus_modify_base_page_queryset
+-------------------------------
+
+Whenever a menu needs page data (whether it be for pages selected as menu items for menu in the CMS, or for something entirely page-tree powered), it calls the ``get_base_page_queryset()`` method first to get a 'base' queryset of pages, then applies additional ``filter()`` and ``exclude()`` statements to filter the result down further, depending on what is needed.
+
+By default, ``get_base_page_queryset()`` applies a few simple filters to prevent certain pages appearing:
+
+
+.. code-block:: python
+
+    Page.objects.filter(live=True, expired=False, show_in_menus=True)
+
+
+However, if you'd like to filter this result down further, you can do so using something like the following: 
+
+
+.. NOTE::
+    The below examples only show a subset of the arguments that are passed to methods using the 'menus_modify_base_page_queryset' hook. For a full list of the arguments supplied, see :ref:`arg_reference_menu_hooks` below.
+
+
+.. code-block:: python
+
+    from wagtail.wagtailcore import hooks
+
+    @hooks.register('menus_modify_base_page_queryset')
+    def make_some_changes(
+        queryset, request, menu_type, root_page, max_levels, use_specific,
+        menu_instance, **kwargs
+    ):
+        """
+        Ensure only pages 'owned' by the currently logged in user are included
+        """
+        if not request.user.is_authenticated():
+            return queryset.none()
+        return queryset.filter(owner=self.request.user)
+
+
+This would ensure that only pages 'owned' by currently logged-in user will appear in menus. And the changes will be applied to ALL types of menu, regardless of what template tag is being called to do the rendering.
+
+Or, if you only wanted to change the queryset for a menu of a specific type, you could modify the code slightly like so:
+
+
+.. code-block:: python
+
+    from wagtail.wagtailcore import hooks
+
+    @hooks.register('menus_modify_base_page_queryset')
+    def make_some_changes(
+        queryset, request, menu_type, root_page, menu_instance, **kwargs
+    ):
+        """
+        Ensure only pages 'owned' by the currently logged in user are included,
+        but only for 'main' or 'flat' menus
+        """
+        if menu_type in ('main_menu', 'flat_menu'):
+            if not request.user.is_authenticated():
+                return queryset.none()
+            queryset = queryset.filter(owner=self.request.user)
+
+        return queryset  # always return a queryset
+
+
+.. _menus_modify_base_menuitem_queryset:
+
+menus_modify_base_menuitem_queryset
+-----------------------------------
+
+When rendering a main or flat menu, the top-level items are defined in the CMS, so the menu must fetch that data first, before it can work out whatever additional data is required for rendering.
+
+By default, ``get_base_menuitem_queryset()`` simply returns all of the menu items that were defined in the CMS. Any page data is then fetched separately (using ``get_base_page_queryset()``), and the two results are combined to ensure that only links to appropriate pages are included.
+
+However, if you'd only like to include a subset of the CMS-defined menu item, or make any further modifications, you can do so using something like the following:
+
+
+.. NOTE::
+    The below examples only show a subset of the arguments that are passed to methods using the 'menus_modify_base_menuitem_queryset' hook. For a full list of the arguments supplied, see :ref:`arg_reference_menu_hooks` below.
+
+
+.. code-block:: python
+
+    from wagtail.wagtailcore import hooks
+
+    @hooks.register('menus_modify_base_menuitem_queryset')
+    def make_some_changes(
+        queryset, request, menu_type, menu_instance, **kwargs
+    ):
+        """
+        If the request is from a specific site, and the current user is
+        authenticated, don't show links to some custom custom URLs
+        """
+        if(
+            request.site.hostname.startswith('intranet.') and 
+            request.user.is_authenticated()
+        ):
+            queryset = queryset.exclude(handle__contains="visiting-only")
+        return queryset  # always return a queryset
+
+
+These changes would be applied to all menu types that use menu items to define the top-level (main and flat menus). If you only wanted to change the queryset for a flat menus, or even a specific flat menu, you could modify the code slightly like so:
+
+
+.. code-block:: python
+
+    from wagtail.wagtailcore import hooks
+
+    @hooks.register('menus_modify_base_menuitem_queryset')
+    def make_some_changes(
+        queryset, request, menu_type, menu_instance, **kwargs
+    ):
+        """
+        When generating a flat menu with the 'action-links' handle, and the
+        request is for a specific site, and the current user is authenticated,
+        don't show links to some custom custom URLs
+        """
+        if(
+            menu_type == 'flat_menu' and 
+            menu_instance.handle == 'action-links' and
+            request.site.hostname.startswith('intranet.') and 
+            request.user.is_authenticated()
+        ):
+            queryset = queryset.exclude(handle__contains="visiting-only")
+        return queryset  # always return a queryset
+
+
+.. _arg_reference_menu_hooks:
+
+Argument reference
+------------------
+
+In the above examples, ``**kwargs`` is used in hook method signatures to make them *accepting* of other keyword arguments, without having to declare every single argument that should be passed in. Defining hook methods in this way also helps to *future-proof* them, allowing them to accept any new arguments that may be added in future versions of wagtailmenus.
+
+Below is a full list of arguments passed that are passed to the above hooks and what they mean:
+
+``queryset``
+    Th Django ``QuerySet`` instance to be modified. For the 'menus_modify_base_page_queryset' hook, this will be a queryset of ``Page`` objects. For the 'menus_modify_base_menuitem_queryset' hook, this will be a queryset of ``MainMenuItem`` or ``FlatMenuItem`` objects (unless you've implemented your own custom menu item models), depending on the type of menu being rendered.
+
+``request``
+    The ``HttpRequest`` object that the menu is currently being rendered for
+
+``menu_type``
+    A string value indicating the 'type' of menu currently being rendered. Should be one of: ``'main_menu'``, ``'flat_menu'``, ``'section_menu'`` or ``'children_menu'``. Comparable to the ``original_menu_tag`` values supplied to other hooks.
+
+``root_page``
+    Supplied to the :ref:`menus_modify_base_page_queryset` hook only. A value will only be provided if the hook is being called from an instance of ``ChildrenMenu`` or ``SecionMenu``, where the contents of the menu is based entirely around a specific page, and it's position in the page tree. For an instance of ChildrenMenu, ``root_page`` will be generally be the page the ``{% children_menu %}`` tag is being rendered on. For an instance of SectionMenu, ``root_page`` will indicate the 'section root' page for the page being rendered (Usually the 'ancestor' page directly below the 'Home page' for the current site).
+
+``menu_instance``
+    The menu instance that is supplying the data required to generate the current menu. This could be an instance of a model class, like ``MainMenu`` or ``FlatMenu``, or a standard python class like ``ChildrenMenu`` or ``SectionMenu``.
+
+``max_levels``
+    An integer value indicatiing the maxiumum number of levels that should be rendered for the current menu. This will either have been specified by the developer using the ``max_levels`` argument of a menu tag, or might have been set in the CMS for a specific ``MainMenu`` or ``FlatMenu`` instance. 
+
+``use_specific``
+    An integer value indicating the preferred policy for using ``PageQuerySet.specific()`` and ``Page.specific`` in rendering the current menu. For more information see: :ref:`specific_pages_tag_args`.
+
+
+Hooks for modifying menu items before rendering
+===============================================
+
+While the above tags are focussed on sourcing data required for a menu, the following hooks are called from within the various menu tags, as they prepare menu items for rendering.
+
+There are two hooks you can use to modify menu items, which are called at different stages of preparation.
+
+
+.. _menus_modify_raw_menu_items:
+
+menus_modify_raw_menu_items
+---------------------------
+
+Whichever menu tag is being used, and whatever the current level being rendered, the tag starts by querying a Menu instance to fetch the items that need to be included as menu items for the current level.
+
+This hook allows you to modify the list of items *as soon as it is fetched* from the menu class, **before** 'priming' (which sets 'href', 'text', 'active_class' and 'has_children_in_menu' attributes on each item), and **before** being sent to any 'modify_submenu_items()' methods for further modification (see :ref:`manipulating_submenu_items`).
+
+
+.. NOTE::
+    The below example only shows a subset of the arguments that are passed to methods using the 'menus_modify_raw_menu_items' hook. For a full list of the arguments supplied, see :ref:`arg_reference_tag_hooks` below.
+
+
+.. code-block:: python
+
+    from wagtail.wagtailcore import hooks
+
+    @hooks.register('menus_modify_base_menuitem_queryset')
+    def make_some_changes(
+        menu_items, request, parent_page, original_menu_tag, menu_instance,
+        current_level, **kwargs
+    ):
+        """
+        When rendering the first level of a 'section menu', add a copy of the
+        first page to the end of the list.
+
+        NOTE: prime_menu_items() will attempt to add 'href', 'text' and other
+        attributes to these items before rendering, so ideally, menu items
+        should all be `MenuItem` or `Page` instances.
+        """
+        if original_menu_tag == 'section_menu' and current_level == 1:
+            # Try/except in case menu_items is an empty list
+            try:
+                menu_items.append(menu_items[0])
+            except KeyError:
+                pass
+        return menu_items
+
+
+The modified list of menu items will then continue to be processed as normal, being passed to `prime_menu_items` for priming, and then on to the parent page's 'modify_submenu_items()' for further modification.
+
+
+.. _menus_modify_primed_menu_items:
+
+menus_modify_primed_menu_items
+------------------------------
+
+This hook allows you to modify the list of items *just before it is passed to a template for rendering*. So, **after** 'priming' (sets 'href', 'text', 'active_class' and 'has_children_in_menu' attributes on each item), and **after** any 'modify_submenu_items()' methods have made their modifications (see :ref:`manipulating_submenu_items`).
+
+.. NOTE::
+    The below example only shows a subset of the arguments that are passed to methods using the 'menus_modify_primed_menu_items' hook. For a full list of the arguments supplied, see :ref:`arg_reference_tag_hooks` below.
+
+
+.. code-block:: python
+
+    from wagtail.wagtailcore import hooks
+
+    @hooks.register('menus_modify_primed_menu_items')
+    def make_some_changes(
+        menu_items, request, parent_page, original_menu_tag, menu_instance,
+        current_level, **kwargs
+    ):
+        """
+        When rendering the first level of a 'main menu', add an additional
+        link to the RKH website
+
+        NOTE: This result won't undergo any more processing before sending to
+        a template for rendering, so you may need to set 'href' and 
+        'text' attributes / keys so that those values are picked up by menu
+        templates.
+        """
+        if original_menu_tag == 'main_menu' and current_level == 1:
+            # Just adding a simple dict here, as these values are all the
+            # template needs to render the link
+            menu_items.append({
+                'href': 'https://rkh.co.uk',
+                'text': 'VISIT RKH.CO.UK',
+                'active_class': 'external',
+            })
+        return menu_items
+
+
+.. _arg_reference_tag_hooks:
+
+Argument reference
+------------------
+
+In the above examples, ``**kwargs`` is used in hook method signatures to make them *accepting* of other keyword arguments, without having to declare every single argument that should be passed in. Defining hook methods in this way also helps to *future-proof* them, allowing them to accept any new arguments that may be added in future versions of wagtailmenus.
+
+Below is a full list of arguments passed that are passed to the above hooks, and what they mean:
+
+``menu_items``
+    The list of menu items to be modified. 
+
+``request``
+    The ``HttpRequest`` object that the menu is currently being rendered for.
+
+``parent_page``
+    If the menu being rendered is showing 'children' of a specific page, this will be the ``Page`` instance who's children pages are being displayed. The value might also be ``None`` if no parent page is involved. For example, if rendering the top level items of a main or flat menu.
+
+``original_menu_tag``
+    The name of the tag that was called to initiate rendering of the menu that is currently being rendered. For example, if you're using the ``main_menu`` tag to render a multi-level menu, even though ``sub_menu`` may be called to render subsequent additional levels, 'original_menu_tag' should retain the value ``'main_menu'``. Should be one of: ``'main_menu'``, ``'flat_menu'``, ``'section_menu'`` or ``'children_menu'``. Comparable to the ``menu_type`` values supplied to other hooks.
+
+``menu_instance``
+    The menu instance that is supplying the data required to generate the current menu. This could be an instance of a model class, like ``MainMenu`` or ``FlatMenu``, or a standard python class like ``ChildrenMenu`` or ``SectionMenu``.
+
+``current_level``
+    An integer value indicating the 'level' or 'depth' that is currently being rendered in the process of rendering a multi-level menu. This will start at `1` for the first/top-level items of a menu, and increment by `1` for each additional level.
+
+``max_levels``
+    An integer value indicatiing the maxiumum number of levels that should be rendered for the current menu. This will either have been specified by the developer using the ``max_levels`` argument of a menu tag, or might have been set in the CMS for a specific ``MainMenu`` or ``FlatMenu`` instance. 
+
+``current_site``
+    A Wagtail ``Site`` instance, indicating the site that the current request is for (usually also available as ``request.site``)
+
+``current_page``
+    A Wagtail ``Page`` instance, indicating what wagtailmenus beleives to be the page that is currently being viewed / requested by a user. This might be ``None`` if you're using standard additional views to provide functionality at urls that don't map to a ``Page`` in Wagtail.
+
+``current_ancestor_ids``
+    A list of ids of ``Page`` instances that are an 'ancestor' of ``current_page``.
+
+``use_specific``
+    An integer value indicating the preferred policy for using ``PageQuerySet.specific()`` and ``Page.specific`` in rendering the current menu. For more information see: :ref:`specific_pages`.
+
+``allow_repeating_parents``
+    A boolean value indicating the preferred policy for having pages that subclass ``MenuPageMixin`` add a repeated versions of themselves to it's children pages (when rendering a `sub_menu` for that page). For more information see: :ref:`menupage_and_menupagemixin`.
+
+``apply_active_classes``
+    A boolean value indicating the preferred policy for setting ``active_class`` attributes on menu items for the current menu.  
+
+``use_absolute_page_urls``
+    A boolean value indicating the preferred policy for using full/absolute page URLs for menu items representing pages (observed by ``prime_menu_items()`` when setting the ``href`` attribute on each menu item). In most cases this will be ``False``, as the default behaviour is to use 'relative' URLs for pages.
+
+

--- a/docs/source/advanced_topics/index.rst
+++ b/docs/source/advanced_topics/index.rst
@@ -6,4 +6,5 @@ Advanced topics
     :maxdepth: 2
 
     specific_pages
+    hooks
     custom_menu_classes

--- a/docs/source/releases/2.5.0a.rst
+++ b/docs/source/releases/2.5.0a.rst
@@ -39,13 +39,16 @@ Bug fixes & minor changes
 *   Updated signature of ``menu_tags.prime_menu_items()`` to improve code
     readability and consistency, and to support additional arguments required
     for new hooks functionality (see below for more details).
-*   All calls to ``prime_menu_items`` are made with arguments in the same order.
-*   All calls to ``get_sub_menu_items_for_page`` are made with arguments in the
-    same order.
 *   The ``stop_at_this_level`` argument for the ``sub_menu`` tag has been
     officially deprecated and the feature removed from documentation. It hasn't 
     worked for a few versions and nobody has mentioned it, so this is the first
     step to removing it completely.
+*   Reduced code bloat in various methods in ``menu_tags.py`` by defining
+    common dictionaries of keyword arguments that can be easily passed to
+    different methods.
+*   Made the logic in 'pages_for_display' easier to override on custom menu
+    classes by breaking it out into a separate 'get_pages_for_display()'
+    method (that isn't decorated with ``cached_property``).
 
 
 Upgrade considerations

--- a/docs/source/releases/2.5.0a.rst
+++ b/docs/source/releases/2.5.0a.rst
@@ -14,6 +14,14 @@ What's new?
 ===========
 
 
+Hooks added to give developers more options for manipulating menus 
+------------------------------------------------------------------
+
+While wagtailmenus has long supported the use of custom classes for most things (allowing developers to override methods as they see fit), for a long time, I've felt that it should be easier to override some core/shared behaviour without the technical overhead of having to create and maintain multiple custom models and classes. So, wagtailmenus now supports several 'hooks', which allow you to do just that.
+
+They use the hooks mechanism from Wagtail, so you may already be familiar with the concept. For more information and examples, see the new :ref:`hooks` section of the documentation.
+
+
 Overriding 'get_base_page_queryset()' now effects top-level menu items too 
 --------------------------------------------------------------------------
 
@@ -136,7 +144,7 @@ This method is only intended for use by the other methods in ``menu_tags.py``, a
 
 The following arguments are now required instead of optional:
 
-* ``original_menu_tag``: The name of the tag that was called to initiate rendering of the menu that is currently being rendered. For example, if you're using the ``main_menu`` tag to render a multi-level menu, even though ``sub_menu`` may be called to render subsequent additional levels, 'original_menu_tag' should retain the value ``'main_menu'``
+* ``original_menu_tag``: The name of the tag that was called to initiate rendering of the menu that is currently being rendered. For example, if you're using the ``main_menu`` tag to render a multi-level menu, even though ``sub_menu`` may be called to render subsequent additional levels, 'original_menu_tag' should retain the value ``'main_menu'``.
 * ``current_level``: An integer indicating the 'level' or 'depth' that is currently being rendered in the process of rendering a multi-level menu.
 * ``max_levels``: An integer indicatiing the maxiumum number of levels that should be rendered for the current menu.
 

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -42,11 +42,10 @@ class Menu(object):
         except AttributeError:
             pass
 
-    def get_default_hook_kwargs(self):
+    def get_common_hook_kwargs(self):
         return {
             'request': self.request,
             'menu_type': self.menu_type,
-            'root_page': self.root_page,
             'max_levels': self.max_levels,
             'use_specific': self.use_specific,
             'menu_instance': self,
@@ -57,7 +56,9 @@ class Menu(object):
             live=True, expired=False, show_in_menus=True)
         # allow hooks to modify the queryset
         for hook in hooks.get_hooks('menus_modify_base_page_queryset'):
-            qs = hook(qs, **self.get_default_hook_kwargs())
+            kwargs = self.get_common_hook_kwargs()
+            kwargs['root_page'] = self.root_page
+            qs = hook(qs, **kwargs)
         return qs
 
     def set_max_levels(self, max_levels):
@@ -110,11 +111,7 @@ class Menu(object):
 
     def get_children_for_page(self, page):
         """Return a list of relevant child pages for a given page."""
-        children = self.page_children_dict.get(page.path, [])
-        # allow hooks to modify the list of children
-        for hook in hooks.get_hooks('menus_modify_children_for_page'):
-            children = hook(children, page, **self.get_default_hook_kwargs())
-        return children
+        return self.page_children_dict.get(page.path, [])
 
     def page_has_children(self, page):
         """Return a boolean indicating whether a given page has any relevant
@@ -178,7 +175,7 @@ class MenuWithMenuItems(ClusterableModel, Menu):
         qs = self.get_menu_items_manager().for_display()
         # allow hooks to modify the queryset
         for hook in hooks.get_hooks('menus_modify_base_menuitem_queryset'):
-            qs = hook(qs, **self.get_default_hook_kwargs())
+            qs = hook(qs, **self.get_common_hook_kwargs())
         return qs
 
     @cached_property

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -8,11 +8,10 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-
 from modelcluster.models import ClusterableModel
-
 from wagtail.wagtailadmin.edit_handlers import (
     FieldPanel, MultiFieldPanel, InlinePanel)
+from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page
 
 from .. import app_settings
@@ -29,7 +28,9 @@ class Menu(object):
     max_levels = 1
     use_specific = app_settings.USE_SPECIFIC_AUTO
     pages_for_display = None
+    root_page = None  # Not relevant for all menu classes
     request = None
+    menu_type = ''  # provided to hook methods
 
     def clear_page_cache(self):
         try:
@@ -41,9 +42,23 @@ class Menu(object):
         except AttributeError:
             pass
 
+    def get_default_hook_kwargs(self):
+        return {
+            'request': self.request,
+            'menu_type': self.menu_type,
+            'root_page': self.root_page,
+            'max_levels': self.max_levels,
+            'use_specific': self.use_specific,
+            'menu_instance': self,
+        }
+
     def get_base_page_queryset(self):
-        return Page.objects.filter(live=True, expired=False,
-                                   show_in_menus=True)
+        qs = Page.objects.filter(
+            live=True, expired=False, show_in_menus=True)
+        # allow hooks to modify the queryset
+        for hook in hooks.get_hooks('menus_modify_base_page_queryset'):
+            qs = hook(qs, **self.get_default_hook_kwargs())
+        return qs
 
     def set_max_levels(self, max_levels):
         if self.max_levels != max_levels:
@@ -95,7 +110,11 @@ class Menu(object):
 
     def get_children_for_page(self, page):
         """Return a list of relevant child pages for a given page."""
-        return self.page_children_dict.get(page.path, [])
+        children = self.page_children_dict.get(page.path, [])
+        # allow hooks to modify the list of children
+        for hook in hooks.get_hooks('menus_modify_children_for_page'):
+            children = hook(children, page, **self.get_default_hook_kwargs())
+        return children
 
     def page_has_children(self, page):
         """Return a boolean indicating whether a given page has any relevant
@@ -141,11 +160,11 @@ class MenuFromRootPage(Menu):
 
 
 class SectionMenu(MenuFromRootPage):
-    pass
+    menu_type = 'section_menu'  # provided to hook methods
 
 
 class ChildrenMenu(MenuFromRootPage):
-    pass
+    menu_type = 'children_menu'  # provided to hook methods
 
 
 class MenuWithMenuItems(ClusterableModel, Menu):
@@ -156,7 +175,11 @@ class MenuWithMenuItems(ClusterableModel, Menu):
         abstract = True
 
     def get_base_menuitem_queryset(self):
-        return self.get_menu_items_manager().for_display()
+        qs = self.get_menu_items_manager().for_display()
+        # allow hooks to modify the queryset
+        for hook in hooks.get_hooks('menus_modify_base_menuitem_queryset'):
+            qs = hook(qs, **self.get_default_hook_kwargs())
+        return qs
 
     @cached_property
     def top_level_items(self):
@@ -240,6 +263,8 @@ class MenuWithMenuItems(ClusterableModel, Menu):
 
 @python_2_unicode_compatible
 class AbstractMainMenu(MenuWithMenuItems):
+    menu_type = 'main_menu'  # provided to hook methods
+
     site = models.OneToOneField(
         'wagtailcore.Site',
         verbose_name=_('site'),
@@ -316,6 +341,8 @@ class AbstractMainMenu(MenuWithMenuItems):
 
 @python_2_unicode_compatible
 class AbstractFlatMenu(MenuWithMenuItems):
+    menu_type = 'flat_menu'  # provided to hook methods
+
     site = models.ForeignKey(
         'wagtailcore.Site',
         verbose_name=_('site'),

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -3,6 +3,7 @@ import warnings
 
 from copy import copy
 from django.template import Library
+from wagtail.wagtailcore import hooks
 from wagtail.wagtailcore.models import Page
 
 from wagtailmenus import app_settings
@@ -657,5 +658,24 @@ def prime_menu_items(
             url = item.relative_url(current_site)
         setattr(item, 'href', url)
         primed_menu_items.append(item)
+
+    # allow hooks to modify the menu_items list further
+    for hook in hooks.get_hooks('menus_modify_menu_items'):
+        primed_menu_items = hook(
+            primed_menu_items,
+            request=request,
+            parent_page=parent_page,
+            original_menu_tag=original_menu_tag,
+            current_level=current_level,
+            max_levels=max_levels,
+            stop_at_this_level=stop_at_this_level,
+            menu_instance=menu_instance,
+            current_site=current_site,
+            current_page=current_page,
+            use_specific=use_specific,
+            apply_active_classes=apply_active_classes,
+            allow_repeating_parents=allow_repeating_parents,
+            use_absolute_page_urls=use_absolute_page_urls,
+        )
 
     return primed_menu_items

--- a/wagtailmenus/tests/test_hooks.py
+++ b/wagtailmenus/tests/test_hooks.py
@@ -1,0 +1,121 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.test import TestCase
+from wagtail.wagtailcore import hooks
+from bs4 import BeautifulSoup
+
+
+class TestHooks(TestCase):
+    fixtures = ['test.json']
+
+    def test_menus_modify_menu_items(self):
+
+        # NOTE: Positional args used to ensure supplied args remain consistent
+        @hooks.register('menus_modify_menu_items')
+        def modify_menu_items(
+            menu_items, request, parent_page, original_menu_tag, menu_instance,
+            current_level, max_levels, stop_at_this_level, current_site,
+            current_page, use_specific, apply_active_classes,
+            allow_repeating_parents, use_absolute_page_urls
+        ):
+            if original_menu_tag == 'main_menu' and current_level == 1:
+                menu_items.append({
+                    'href': 'https://rkh.co.uk',
+                    'text': 'VISIT RKH.CO.UK',
+                    'active_class': 'external',
+                })
+            return menu_items
+
+        # Let's render the test homepage to see what happens!
+        response = self.client.get('/')
+
+        # unhook asap to prevent knock-on effects on failure
+        del hooks._hooks['menus_modify_menu_items']
+
+        # If the the hook failed to recieve any of the arguments defined
+        # on `modify_menu_items` above, there will be an error
+        self.assertEqual(response.status_code, 200)
+
+        # There are 4 main menus being output, and because our hook only adds
+        # the additional item to the first level of each of those, the
+        # 'VISIT RKH.CO.UK' text should appear exactly 4 times
+        self.assertContains(response, 'VISIT RKH.CO.UK', 4)
+
+    def test_menus_modify_base_page_queryset(self):
+
+        # NOTE: Positional args used to ensure supplied args remain consistent
+        @hooks.register('menus_modify_base_page_queryset')
+        def modify_page_queryset(
+            queryset, request, menu_type, root_page, max_levels, use_specific,
+            menu_instance
+        ):
+            """
+            Nullify page queryset for 'flat menus'. Should result in only
+            links to custom urls being rendered.
+            """
+            if menu_type == 'flat_menu':
+                queryset = queryset.none()
+            return queryset
+
+        # Let's render the test homepage to see what happens!
+        response = self.client.get('/')
+
+        # unhook asap to prevent knock-on effects on failure
+        del hooks._hooks['menus_modify_base_page_queryset']
+
+        # If the the hook failed to recieve any of the arguments defined
+        # on `modify_menu_items` above, there will be an error
+        self.assertEqual(response.status_code, 200)
+
+        # Test output reflects hook changes
+        soup = BeautifulSoup(response.content, 'html5lib')
+        contact_menu_html = soup.find(id='nav-contact').decode()
+        # 'Call us' is a page link, so should no longer appear
+        expected_html = """
+        <div id="nav-contact">
+            <div class="flat-menu contact no_heading">
+                <ul>
+                    <li class=""><a href="#advisor-chat">Chat to an advisor</a></li>
+                    <li class=""><a href="#request-callback">Request a callback</a></li>
+                </ul>
+            </div>
+        </div>
+        """
+        self.assertHTMLEqual(contact_menu_html, expected_html)
+
+    def test_menus_modify_base_menuitem_queryset(self):
+
+        # NOTE: Positional args used to ensure supplied args remain consistent
+        @hooks.register('menus_modify_base_menuitem_queryset')
+        def modify_menuitem_queryset(
+            queryset, request, menu_type, root_page, max_levels, use_specific,
+            menu_instance
+        ):
+            """
+            Nullify menu items completely for all 'flat menus'. Should result
+            in completely empty menus
+            """
+            if menu_type == 'flat_menu':
+                queryset = queryset.none()
+            return queryset
+
+        # Let's render the test homepage to see what happens!
+        response = self.client.get('/')
+
+        # unhook asap to prevent knock-on effects on failure
+        del hooks._hooks['menus_modify_base_menuitem_queryset']
+
+        # If the the hook failed to recieve any of the arguments defined
+        # on `modify_menu_items` above, there will be an error
+        self.assertEqual(response.status_code, 200)
+
+        # Test output reflects hook changes
+        soup = BeautifulSoup(response.content, 'html5lib')
+        contact_menu_html = soup.find(id='nav-contact').decode()
+        # There should be no menu items, so just an empty div (no <ul>)
+        expected_html = """
+        <div id="nav-contact">
+            <div class="flat-menu contact no_heading"></div>
+        </div>
+        """
+        self.assertHTMLEqual(contact_menu_html, expected_html)

--- a/wagtailmenus/tests/test_hooks.py
+++ b/wagtailmenus/tests/test_hooks.py
@@ -8,14 +8,14 @@ from bs4 import BeautifulSoup
 class TestHooks(TestCase):
     fixtures = ['test.json']
 
-    def test_menus_modify_menu_items(self):
+    def test_menus_modify_primed_menu_items(self):
 
         # NOTE: Positional args used to ensure supplied args remain consistent
-        @hooks.register('menus_modify_menu_items')
+        @hooks.register('menus_modify_primed_menu_items')
         def modify_menu_items(
             menu_items, request, parent_page, original_menu_tag, menu_instance,
-            current_level, max_levels, stop_at_this_level, current_site,
-            current_page, use_specific, apply_active_classes,
+            current_level, max_levels, current_site, current_page,
+            current_ancestor_ids, use_specific, apply_active_classes,
             allow_repeating_parents, use_absolute_page_urls
         ):
             if original_menu_tag == 'main_menu' and current_level == 1:
@@ -30,9 +30,9 @@ class TestHooks(TestCase):
         response = self.client.get('/')
 
         # unhook asap to prevent knock-on effects on failure
-        del hooks._hooks['menus_modify_menu_items']
+        del hooks._hooks['menus_modify_primed_menu_items']
 
-        # If the the hook failed to recieve any of the arguments defined
+        # If the the hook failed to receive any of the arguments defined
         # on `modify_menu_items` above, there will be an error
         self.assertEqual(response.status_code, 200)
 
@@ -40,6 +40,57 @@ class TestHooks(TestCase):
         # the additional item to the first level of each of those, the
         # 'VISIT RKH.CO.UK' text should appear exactly 4 times
         self.assertContains(response, 'VISIT RKH.CO.UK', 4)
+
+    def test_menus_modify_raw_menu_items(self):
+
+        # NOTE: Positional args used to ensure supplied args remain consistent
+        @hooks.register('menus_modify_raw_menu_items')
+        def modify_menu_items(
+            menu_items, request, parent_page, original_menu_tag, menu_instance,
+            current_level, max_levels, current_site, current_page,
+            current_ancestor_ids, use_specific, apply_active_classes,
+            allow_repeating_parents, use_absolute_page_urls
+        ):
+            if original_menu_tag == 'section_menu' and current_level == 1:
+                """
+                For the first level of section menus, add a copy of the first
+                page to the end of the list
+                """
+                try:
+                    menu_items.append(menu_items[0])
+                except KeyError:
+                    pass
+            return menu_items
+
+        # Let's render the 'about us' page to see what happens!
+        response = self.client.get('/about-us/')
+
+        # unhook asap to prevent knock-on effects on failure
+        del hooks._hooks['menus_modify_raw_menu_items']
+
+        # If the the hook failed to receive any of the arguments defined
+        # on `modify_menu_items` above, there will be an error
+        self.assertEqual(response.status_code, 200)
+
+        # Test output reflects hook changes
+        soup = BeautifulSoup(response.content, 'html5lib')
+        section_menu_html = soup.find(id='section-menu-one-level').decode()
+        # 'Call us' is a page link, so should no longer appear
+        expected_html = """
+        <div id="section-menu-one-level">
+            <nav class="nav-section" role="navigation">
+                <a href="/about-us/" class="ancestor section_root">About us</a>
+                <ul>
+                    <li class="active"><a href="/about-us/">Section home</a></li>
+                    <li class=""><a href="/about-us/meet-the-team/">Meet the team</a></li>
+                    <li class=""><a href="/about-us/our-heritage/">Our heritage</a></li>
+                    <li class=""><a href="/about-us/mission-and-values/">Our mission and values</a></li>
+                    <li class=""><a href="/about-us/meet-the-team/">Meet the team</a></li>
+                </ul>
+            </nav>
+        </div>
+        """
+        self.assertHTMLEqual(section_menu_html, expected_html)
 
     def test_menus_modify_base_page_queryset(self):
 
@@ -63,7 +114,7 @@ class TestHooks(TestCase):
         # unhook asap to prevent knock-on effects on failure
         del hooks._hooks['menus_modify_base_page_queryset']
 
-        # If the the hook failed to recieve any of the arguments defined
+        # If the the hook failed to receive any of the arguments defined
         # on `modify_menu_items` above, there will be an error
         self.assertEqual(response.status_code, 200)
 
@@ -105,7 +156,7 @@ class TestHooks(TestCase):
         # unhook asap to prevent knock-on effects on failure
         del hooks._hooks['menus_modify_base_menuitem_queryset']
 
-        # If the the hook failed to recieve any of the arguments defined
+        # If the the hook failed to receive any of the arguments defined
         # on `modify_menu_items` above, there will be an error
         self.assertEqual(response.status_code, 200)
 

--- a/wagtailmenus/tests/test_hooks.py
+++ b/wagtailmenus/tests/test_hooks.py
@@ -97,8 +97,7 @@ class TestHooks(TestCase):
         # NOTE: Positional args used to ensure supplied args remain consistent
         @hooks.register('menus_modify_base_page_queryset')
         def modify_page_queryset(
-            queryset, request, menu_type, root_page, max_levels, use_specific,
-            menu_instance
+            queryset, request, menu_type, root_page, max_levels, use_specific, menu_instance
         ):
             """
             Nullify page queryset for 'flat menus'. Should result in only
@@ -139,8 +138,7 @@ class TestHooks(TestCase):
         # NOTE: Positional args used to ensure supplied args remain consistent
         @hooks.register('menus_modify_base_menuitem_queryset')
         def modify_menuitem_queryset(
-            queryset, request, menu_type, root_page, max_levels, use_specific,
-            menu_instance
+            queryset, request, menu_type, max_levels, use_specific, menu_instance
         ):
             """
             Nullify menu items completely for all 'flat menus'. Should result


### PR DESCRIPTION
Fixes #159.

While wagtailmenus has long supported the use of custom classes for most things (allowing developers to override methods as they see fit), for a long time, I've felt that it should be easier to override some core/shared behaviour without the technical overhead of having to create and maintain multiple custom models and classes.

This PR adds support for several 'hooks' to allow behaviour to be customised more easily. 

The documentation explains what each hook does and provides some example implementations to copy from.