### PR TITLE
Add support for Wagtail 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ matrix:
     python: 3.6 
   - env: TOXENV=py36-dj111-wt111
     python: 3.6 
+  - env: TOXENV=py36-dj111-wt112
+    python: 3.6 
 
 install:
 - pip install tox codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Changelog
   querysets and manipulation of menu items during rendering. For more
   information and examples, see the 'Hooks' section of the documentation:
   http://wagtailmenus.readthedocs.io/en/latest/advanced_topics/hooks.html
+* Added support for Wagtail 1.12.
 
 
 2.4.0 (04.08.2017)

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ wagtailmenus
 
 wagtailmenus is an extension for Torchbox's `Wagtail CMS <https://github.com/torchbox/wagtail>`_ to help you manage and render multi-level navigation and simple flat menus in a consistent, flexible way.
 
-The current version is compatible with Wagtail 1.5 to 1.11 and Python 2.7, 3.3, 3.4, 3.5 and 3.6.
+The current version is compatible with Wagtail 1.5 to 1.12 and Python 2.7, 3.3, 3.4, 3.5 and 3.6.
 
 .. image:: https://raw.githubusercontent.com/rkhleics/wagtailmenus/master/docs/source/_static/images/repeating-item.png
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,7 +5,7 @@ Welcome to the wagtailmenus documentation!
 wagtailmenus is an open-source extension for `Wagtail CMS
 <https://github.com/torchbox/wagtail>`_ to help you define, manage and render menus in a consistent, yet flexible way.
 
-The current version is compatible with Wagtail 1.5 to 1.11 and Python 2.7, 3.3, 3.4, 3.5 and 3.6.
+The current version is compatible with Wagtail 1.5 to 1.12 and Python 2.7, 3.3, 3.4, 3.5 and 3.6.
 
 To find out more about what wagtailmenus does and why, see :doc:`overview`
 

--- a/docs/source/releases/2.5.0a.rst
+++ b/docs/source/releases/2.5.0a.rst
@@ -57,6 +57,7 @@ Bug fixes & minor changes
 *   Made the logic in 'pages_for_display' easier to override on custom menu
     classes by breaking it out into a separate 'get_pages_for_display()'
     method (that isn't decorated with ``cached_property``).
+*   Added support for Wagtail 1.12
 
 
 Upgrade considerations

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = True
 
 envlist = 
-    py{27,33,34,35,36}-dj{18,19,110,111}-wt{15,16,17,18,19,110,111}
+    py{27,33,34,35,36}-dj{18,19,110,111}-wt{15,16,17,18,19,110,111,112}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -28,3 +28,4 @@ deps =
     wt19: wagtail>=1.9,<1.10
     wt110: wagtail>=1.10,<1.11
     wt111: wagtail>=1.11,<1.12
+    wt112: wagtail>=1.12,<1.13


### PR DESCRIPTION
Add tox test environment to test codebase with wagtail 1.12 and update bits in readme and docs that specify wagtail version support.