### PR TITLE
Make template engine neutrality changes backwards-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 Changelog
 =========
 
-2.X.X (XX.XX.XXXX) IN DEVELOPMENT
+2.6.0 (XX.XX.XXXX) IN DEVELOPMENT
 --------------------------------- 
+
+* Improve compatibility with alternative template backends such as `jinja2`.
+  Implementation by @hongquan.
+* Added compatibility with `wagtail-condensedinlinepanel`.
+* Updated the menu CMS editing UI to split rendering setting field out into 
+  their own tab.
 
 
 2.5.1 (27.10.2017)

--- a/docs/source/releases/2.6.0.rst
+++ b/docs/source/releases/2.6.0.rst
@@ -10,6 +10,21 @@ Wagtailmenus 2.6.0 release notes
 What's new?
 ===========
 
+Improved compatibility with alternative template backends
+---------------------------------------------------------
+
+Wagtailmenus has been updated to use backend-specific templates for rendering, making it compatible with template backends other than Django's default backend (such as ``jinja2``).
+
+Although the likelihood of this new behavior introducing breaking changes to projects is minute, it is turned **OFF** by default for now, in order to give developers time to make any necessary changes. However, by version 2.8 the updated behaviour will replace the old behaviour completely, becoming non optional.
+
+To start using wagtailmenus with an alternative backend now (or to test your project's compatibility in advance), you can turn the updated behaviour **ON** by adding the following to your project's settings:
+
+.. code:: python
+
+    WAGTAILMENUS_USE_BACKEND_SPECIFIC_TEMPLATES = True
+
+Thank you to Nguyễn Hồng Quân (hongquan) for contributing this!
+
 
 New tabbed interface for menu editing
 -------------------------------------
@@ -84,13 +99,25 @@ Minor changes & bug fixes
 N/A
 
 
-Upgrade considerations
-======================
+Deprecations
+============
 
 
-``AbstractMainMenu.panels`` and ``AbstractFlatMenu.panels`` attributes are now deprecated
------------------------------------------------------------------------------------------
+``Menu.get_template_engine()``
+------------------------------
+
+This method is deprecated in favour of using Django's generic 'get_template' and 'select_template' methods, which return backend-specific template instances instead of `django.template.Template` instances.
+
+
+``AbstractMainMenu.panels`` and ``AbstractFlatMenu.panels``
+-----------------------------------------------------------
 
 If you are referencing ``AbstractMainMenu.panels`` or ``AbstractFlatMenu.panels`` anywhere, you should update your code to reference the ``content_panels`` or ``settings_panels`` attribute instead, depending on which panels you're trying to make use of. 
 
 If you're overriding the ``panels`` attribute on a custom menu model in order to make additional fields available in the editing UI (or change the default field display order), you might also want to think about updating your code to override the ``content_panels`` and ``settings_panels`` attributes instead, which will result in fields being split between two tabs (**Content** and **Settings**). However, this is entirely optional.
+
+
+Upgrade considerations
+======================
+
+N/A

--- a/wagtailmenus/app_settings.py
+++ b/wagtailmenus/app_settings.py
@@ -204,6 +204,11 @@ class AppSettings(object):
     def SECTION_MENU_CLASS(self):
         return self.class_from_path_setting('SECTION_MENU_CLASS_PATH')
 
+    # TODO: To be removed in v2.8.0
+    @property
+    def USE_BACKEND_SPECIFIC_TEMPLATES(self):
+        return self._setting('USE_BACKEND_SPECIFIC_TEMPLATES', False)
+
 
 import sys  # noqa
 

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -48,18 +48,21 @@ OptionVals = namedtuple('OptionVals', (
     'handle', 'template_name', 'sub_menu_template_name', 'extra'
 ))
 
+
 # TODO: To be removed in v.2.8.0
+TEMPLATES_WARNING = (
+    "Wagtailmenus currently uses django.template.Template instances for "
+    "rendering by default. This will change in 2.8 in favour of always using "
+    "backend-specific template instances (allowing wagtailmenus to be used "
+    "with template backends other than Django's default). In most cases, this "
+    "change will require no action at all. If you'd like to check, you can "
+    "enable the new behaviour by adding "
+    "'WAGTAILMENUS_USE_BACKEND_SPECIFIC_TEMPLATES = True' to your project's "
+    "settings. See the 2.6 release notes for more info: "
+    "https://github.com/rkhleics/wagtailmenus/releases/tag/v.2.6.0"
+)
 if not app_settings.USE_BACKEND_SPECIFIC_TEMPLATES:
-    warning_msg = (
-        "You're currently using wagtailmenus in a mode that uses "
-        "django.template.Template instances for rendering. This option "
-        "will be removed in v2.8 in favour of using backend-specific "
-        "templates. You switch to using the new behaviour now by adding "
-        "'WAGTAILMENUS_USE_BACKEND_SPECIFIC_TEMPLATES = True' to your project "
-        "settings. View the 2.6 release notes to find out more: "
-        "https://github.com/rkhleics/wagtailmenus/releases/tag/v.2.6.0"
-    )
-    warnings.warn(warning_msg, category=RemovedInWagtailMenus28Warning)
+    warnings.warn(TEMPLATES_WARNING, category=RemovedInWagtailMenus28Warning)
 
 
 # ########################################################

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -49,8 +49,7 @@ OptionVals = namedtuple('OptionVals', (
 ))
 
 # TODO: To be removed in v.2.8.0
-USE_BACKEND_SPECIFIC_TEMPLATES = app_settings.USE_BACKEND_SPECIFIC_TEMPLATES
-if not USE_BACKEND_SPECIFIC_TEMPLATES:
+if not app_settings.USE_BACKEND_SPECIFIC_TEMPLATES:
     warning_msg = (
         "You're currently using wagtailmenus in a mode that uses "
         "django.template.Template instances for rendering. This option "
@@ -206,7 +205,7 @@ class Menu(object):
         template = self.get_template()
 
         # TODO: To be removed in v2.8.0
-        if not USE_BACKEND_SPECIFIC_TEMPLATES:
+        if not app_settings.USE_BACKEND_SPECIFIC_TEMPLATES:
             context_data['current_template'] = template.name
             return template.render(Context(context_data))
 
@@ -545,12 +544,12 @@ class Menu(object):
         return menu_items
 
     def get_template_engine(self):
-        if USE_BACKEND_SPECIFIC_TEMPLATES:
+        if app_settings.USE_BACKEND_SPECIFIC_TEMPLATES:
             warning_msg = (
                 "The 'get_template_engine' method is deprecated in favour of "
                 "using Django's generic 'get_template' and 'select_template' "
-                "methods. View the 2.6 release notes for more info: "
-                "https://github.com/rkhleics/wagtailmenus/releases/tag/v.2.6.0"
+                "methods. See the 2.6 release notes for more info: "
+                "https://github.com/rkhleics/wagtailmenus/releases/tag/v2.6.0"
             )
             warnings.warn(warning_msg, category=RemovedInWagtailMenus28Warning)
         return self._contextual_vals.parent_context.template.engine
@@ -559,7 +558,7 @@ class Menu(object):
         template_name = self._option_vals.template_name or self.template_name
 
         # TODO: To be removed in v2.8.0
-        if not USE_BACKEND_SPECIFIC_TEMPLATES:
+        if not app_settings.USE_BACKEND_SPECIFIC_TEMPLATES:
             engine = self.get_template_engine()
             if template_name:
                 return engine.get_template(template_name)

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -53,13 +53,11 @@ OptionVals = namedtuple('OptionVals', (
 TEMPLATES_WARNING = (
     "Wagtailmenus currently uses django.template.Template instances for "
     "rendering by default. This will change in 2.8 in favour of always using "
-    "backend-specific template instances (allowing wagtailmenus to be used "
-    "with template backends other than Django's default). In most cases, this "
-    "change will require no action at all. If you'd like to check, you can "
-    "enable the new behaviour by adding "
-    "'WAGTAILMENUS_USE_BACKEND_SPECIFIC_TEMPLATES = True' to your project's "
-    "settings. See the 2.6 release notes for more info: "
-    "https://github.com/rkhleics/wagtailmenus/releases/tag/v.2.6.0"
+    "backend-specific template instances. You can use thie new behaviour "
+    "right now by adding 'WAGTAILMENUS_USE_BACKEND_SPECIFIC_TEMPLATES = True' "
+    "to your project's settings (which will also silence this warning). See "
+    "the 2.6 release notes for more info: "
+    "http://wagtailmenus.readthedocs.io/en/stable/releases/2.6.0.html"
 )
 if not app_settings.USE_BACKEND_SPECIFIC_TEMPLATES:
     warnings.warn(TEMPLATES_WARNING, category=RemovedInWagtailMenus28Warning)
@@ -547,14 +545,13 @@ class Menu(object):
         return menu_items
 
     def get_template_engine(self):
-        if app_settings.USE_BACKEND_SPECIFIC_TEMPLATES:
-            warning_msg = (
-                "The 'get_template_engine' method is deprecated in favour of "
-                "using Django's generic 'get_template' and 'select_template' "
-                "methods. See the 2.6 release notes for more info: "
-                "https://github.com/rkhleics/wagtailmenus/releases/tag/v2.6.0"
-            )
-            warnings.warn(warning_msg, category=RemovedInWagtailMenus28Warning)
+        warning_msg = (
+            "The get_template_engine() method is deprecated in favour of "
+            "using Django's generic 'get_template' and 'select_template' "
+            "methods. See the 2.6 release notes for more info: "
+            "http://wagtailmenus.readthedocs.io/en/stable/releases/2.6.0.html"
+        )
+        warnings.warn(warning_msg, category=RemovedInWagtailMenus28Warning)
         return self._contextual_vals.parent_context.template.engine
 
     def get_template(self):

--- a/wagtailmenus/tests/test_menu_rendering.py
+++ b/wagtailmenus/tests/test_menu_rendering.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase, override_settings
-
 from wagtail.wagtailcore.models import Site
 from wagtailmenus.errors import SubMenuUsageError
 from wagtailmenus.models import MainMenu, FlatMenu
@@ -1488,3 +1487,8 @@ class TestTemplateTags(TestCase):
         </div>
         """
         self.assertHTMLEqual(section_menu_html, expected_section_menu_html)
+
+
+@override_settings(WAGTAILMENUS_USE_BACKEND_SPECIFIC_TEMPLATES=True)
+class TestRenderingWithBackendSpecificTemplates(TestTemplateTags):
+    pass


### PR DESCRIPTION
Follows the approach outlined in #194 to make some recent changes fully backwards compatible 