### PR TITLE
Designate 2.6 as LTS release and announce dropping of Python 2 support

### DIFF
--- a/docs/source/releases/2.6.0a.rst
+++ b/docs/source/releases/2.6.0a.rst
@@ -15,6 +15,10 @@ Wagtailmenus 2.6.0a release notes
 
     Wagtailmenus 2.6 will be the last LTS release to support Python 2.
 
+.. NOTE ::
+
+    Wagtailmenus 2.6 will be the last LTS release to support Wagtail versions 1.5 to 1.9.
+
 
 What's new?
 ===========

--- a/docs/source/releases/2.6.0a.rst
+++ b/docs/source/releases/2.6.0a.rst
@@ -7,6 +7,15 @@ Wagtailmenus 2.6.0a release notes
     :depth: 1
 
 
+.. NOTE ::
+    
+    Wagtailmenus 2.6 is designated a Long Term Support (LTS) release. Long Term Support releases will continue to receive maintenance updates as necessary to address security and data-loss related issues, up until the next LTS release (for at least 8 months). 
+
+.. NOTE ::
+
+    Wagtailmenus 2.6 will be the last LTS release to support Python 2.
+
+
 What's new?
 ===========
 


### PR DESCRIPTION
Related to #198