### PR TITLE
Adds support for Wagtail 2.0 and Django 2.0 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
   include: 
   - env: TOXENV=py34-dj110-wt110
     python: 3.4 
-  - env: TOXENV=py35-dj10-wt111
+  - env: TOXENV=py35-dj110-wt111
     python: 3.5 
   - env: TOXENV=py36-dj110-wt112
     python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,10 @@ sudo: required
 
 matrix:
   include: 
-  - env: TOXENV=py34-dj18-wt110
+  - env: TOXENV=py36-dj110-wt110
     python: 3.4 
-  - env: TOXENV=py35-dj18-wt110
+  - env: TOXENV=py36-dj10-wt111
     python: 3.5 
-  - env: TOXENV=py36-dj18-wt110
-    python: 3.6 
-  - env: TOXENV=py36-dj19-wt111
-    python: 3.6 
   - env: TOXENV=py36-dj110-wt112
     python: 3.6
   - env: TOXENV=py36-dj111-wt113

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
     python: 3.6
   - env: TOXENV=py36-dj111-wt113
     python: 3.6
+  - env: TOXENV=py36-dj111-wt2
+    python: 3.6
+  - env: TOXENV=py36-dj2-wt2
+    python: 3.6
 
 install:
 - pip install tox codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ sudo: required
 
 matrix:
   include: 
-  - env: TOXENV=py36-dj110-wt110
+  - env: TOXENV=py34-dj110-wt110
     python: 3.4 
-  - env: TOXENV=py36-dj10-wt111
+  - env: TOXENV=py35-dj10-wt111
     python: 3.5 
   - env: TOXENV=py36-dj110-wt112
     python: 3.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Changelog
 2.7.0a (XX.XX.XXXX) IN DEVELOPMENT
 ----------------------------------
 
-TBA
+* Added support for Wagtail 2.0 and Django 2.0
+* Dropped support for Wagtail versions 1.8 to 1.9
+* Dropped support for Django versions 1.5 to 1.9
 
 
 2.6.0 (22.12.2017)

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,8 @@ wagtailmenus is an extension for Torchbox's `Wagtail CMS <https://github.com/tor
 
 The current version is tested for compatiblily with the following: 
 
-- Wagtail versions 1.10 to 1.13
-- Django versions 1.8 to 1.11
+- Wagtail versions 1.10 to 2.0
+- Django versions 1.10 to 2.0
 - Python versions 3.4 to 3.6
 
 .. image:: https://raw.githubusercontent.com/rkhleics/wagtailmenus/master/docs/source/_static/images/repeating-item.png

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,8 +7,8 @@ wagtailmenus is an open-source extension for `Wagtail CMS
 
 The current version is tested for compatiblily with the following: 
 
-- Wagtail versions 1.10 to 1.13
-- Django versions 1.8 to 1.11
+- Wagtail versions 1.10 to 2.0
+- Django versions 1.10 to 2.0
 - Python versions 3.4 to 3.6
 
 To find out more about what wagtailmenus does and why, see :doc:`overview`

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -123,7 +123,10 @@ Installing wagtailmenus
 Installing ``wagtail-condensedinlinepanel``
 ===========================================
 
-Although doing so is entirely optional, for an all-round better menu editing experience, we recommend using wagtailmenus together with `wagtail-condensedinlinepanel <https://github.com/wagtail/wagtail-condensedinlinepanel>`_ (version ``0.3`` or above). 
+Although doing so is entirely optional, for an all-round better menu editing experience, we recommend using wagtailmenus together with `wagtail-condensedinlinepanel <https://github.com/wagtail/wagtail-condensedinlinepanel>`_.
+
+.. NOTE::
+    ``wagtail-condensedinlinepanel`` hasn't yet released a version compatible with Wagtail 2.0 (you'll have to wait for version ``0.5`` that!). If you're using an earlier version of Wagtail, the latest version of wagtail-condensedinlinepanel (``0.4.2``) should work nicely for you.
 
 ``wagtail-condensedinlinepanel`` offers a React-powered alternative to Wagtail's built-in ``InlinePanel`` with some great extra features that make it perfect for managing menu items; including drag-and-drop reordering and the ability to add new items at any position. 
 

--- a/docs/source/releases/2.7.0a.rst
+++ b/docs/source/releases/2.7.0a.rst
@@ -16,23 +16,18 @@ Wagtailmenus 2.7 (alpha) release notes
 What's new?
 ===========
 
-TBA
-
-
-Minor changes & bug fixes 
-=========================
-
-TBA
-
-
-Deprecations
-============
-
-TBA
+- Added support for Wagtail 2.0 and Django 2.0
+- Dropped support for Wagtail versions 1.8 to 1.9
+- Dropped support for Django versions 1.5 to 1.9
 
 
 Upgrade considerations
 ======================
+
+- Wagtailmenus now only officially supports Wagtail and Django versions from
+  1.10 to 2.0. If you're using anything earlier than that, you should consider
+  updating your project. If upgrading Wagtail or Django isn't an option, you 
+  should stick with wagtailmenus 2.6 for now, which is a LTS release.
 
 Following the standard deprecation period, the following classes, methods and
 behaviour has been removed:

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
-        'Framework :: Django :: 1.8',
-        'Framework :: Django :: 1.9',
         'Framework :: Django :: 1.10',
         'Framework :: Django :: 1.11',
         'Topic :: Internet :: WWW/HTTP',

--- a/tox.ini
+++ b/tox.ini
@@ -22,13 +22,8 @@ deps =
     dj110: Django>=1.10a1,<1.11
     dj111: Django>=1.11,<1.12
     dj2: Django>=2.0,<2.1
-    wt15: wagtail>=1.5.1,<1.6
-    wt16: wagtail>=1.6,<1.7
-    wt17: wagtail>=1.7,<1.8
-    wt18: wagtail>=1.8,<1.9
-    wt19: wagtail>=1.9,<1.10
     wt110: wagtail>=1.10,<1.11
     wt111: wagtail>=1.11,<1.12
     wt112: wagtail>=1.12,<1.13
     wt113: wagtail>=1.13,<2.0
-    wt2: wagtail>=2.0,<2.1
+    wt2: wagtail==2.0.0b1

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ skipsdist = True
 usedevelop = True
 
 envlist = 
-    py{34,35,36}-dj{18,19,110,111,2}-wt{110,111,112,113,2}
+    py{34,35,36}-dj{110,111,2}-wt{110,111,112,113,2}
 
 [testenv]
 install_command = pip install -e ".[testing]" -U {opts} {packages}
@@ -15,11 +15,7 @@ basepython =
     py36: python3.6
 
 deps =
-    dj18: Django>=1.8.1,<1.9
-    dj18: djangorestframework==3.7.3
-    dj19: Django>=1.9,<1.10
-    dj19: djangorestframework==3.7.3
-    dj110: Django>=1.10a1,<1.11
+    dj110: Django>=1.10,<1.11
     dj111: Django>=1.11,<1.12
     dj2: Django>=2.0,<2.1
     wt110: wagtail>=1.10,<1.11

--- a/wagtailmenus/forms.py
+++ b/wagtailmenus/forms.py
@@ -1,7 +1,10 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
-
-from wagtail.wagtailadmin.forms import WagtailAdminModelForm, WagtailAdminPageForm
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
+else:
+    from wagtail.wagtailadmin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 
 from . import app_settings
 

--- a/wagtailmenus/management/commands/autopopulate_main_menus.py
+++ b/wagtailmenus/management/commands/autopopulate_main_menus.py
@@ -1,8 +1,12 @@
 import logging
 
 from django.core.management.base import BaseCommand
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Site
+else:
+    from wagtail.wagtailcore.models import Site
 
-from wagtail.wagtailcore.models import Site
 from wagtailmenus import app_settings
 
 logger = logging.getLogger(__name__)

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -1,11 +1,14 @@
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-
 from modelcluster.fields import ParentalKey
-
-from wagtail.wagtailadmin.edit_handlers import FieldPanel, PageChooserPanel
-from wagtail.wagtailcore.models import Orderable
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
+    from wagtail.core.models import Page, Orderable
+else:
+    from wagtail.wagtailadmin.edit_handlers import FieldPanel, PageChooserPanel
+    from wagtail.wagtailcore.models import Page, Orderable
 
 from .. import app_settings
 from ..managers import MenuItemManager
@@ -28,7 +31,7 @@ class AbstractMenuItem(models.Model, MenuItem):
     """A model class that defines a base set of fields and methods for all
     'menu item' models."""
     link_page = models.ForeignKey(
-        'wagtailcore.Page',
+        Page,
         verbose_name=_('link to an internal page'),
         blank=True,
         null=True,

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -11,9 +11,13 @@ from django.utils.functional import cached_property, lazy
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from modelcluster.models import ClusterableModel
-
-from wagtail.wagtailcore import hooks
-from wagtail.wagtailcore.models import Page
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core import hooks
+    from wagtail.core.models import Page, Site
+else:
+    from wagtail.wagtailcore import hooks
+    from wagtail.wagtailcore.models import Page, Site
 
 from .. import app_settings
 from ..forms import FlatMenuAdminForm

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -5,8 +5,11 @@ from django.db import models
 from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
-
-from wagtail.wagtailcore.models import Page
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Page
+else:
+    from wagtail.wagtailcore.models import Page
 
 from .. import app_settings
 from ..forms import LinkPageAdminForm

--- a/wagtailmenus/panels.py
+++ b/wagtailmenus/panels.py
@@ -2,12 +2,19 @@ from distutils.version import LooseVersion
 
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-
-from wagtail.wagtailadmin.edit_handlers import (
-    FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel, PageChooserPanel,
-    ObjectList, TabbedInterface)
-
 from . import app_settings
+
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.admin.edit_handlers import (
+        FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel,
+        PageChooserPanel, ObjectList, TabbedInterface
+    )
+else:
+    from wagtail.wagtailadmin.edit_handlers import (
+        FieldPanel, FieldRowPanel, InlinePanel, MultiFieldPanel,
+        PageChooserPanel, ObjectList, TabbedInterface
+    )
 
 
 # ########################################################

--- a/wagtailmenus/settings/base.py
+++ b/wagtailmenus/settings/base.py
@@ -1,5 +1,7 @@
 import os
+from django import VERSION as DJANGO_VERSION
 from django.conf.global_settings import *  # NOQA
+from wagtail import VERSION as WAGTAIL_VERSION
 
 DEBUG = True
 SITE_ID = 1
@@ -12,19 +14,6 @@ LANGUAGE_CODE = 'en'
 
 
 INSTALLED_APPS = (
-    'wagtail.contrib.settings',
-    'wagtail.wagtailforms',
-    'wagtail.wagtailsearch',
-    'wagtail.wagtailembeds',
-    'wagtail.wagtailimages',
-    'wagtail.wagtailsites',
-    'wagtail.wagtailusers',
-    'wagtail.wagtailsnippets',
-    'wagtail.wagtaildocs',
-    'wagtail.wagtailredirects',
-    'wagtail.wagtailadmin',
-    'wagtail.wagtailcore',
-    'wagtail.contrib.modeladmin',
     'wagtailmenus',
 
     'taggit',
@@ -36,8 +25,36 @@ INSTALLED_APPS = (
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.sites'
+    'django.contrib.sites',
+    'wagtail.contrib.settings',
+    'wagtail.contrib.modeladmin',
 )
+if WAGTAIL_VERSION >= (2, 0):
+    INSTALLED_APPS += (
+        'wagtail.search',
+        'wagtail.embeds',
+        'wagtail.images',
+        'wagtail.sites',
+        'wagtail.users',
+        'wagtail.snippets',
+        'wagtail.documents',
+        'wagtail.contrib.redirects',
+        'wagtail.admin',
+        'wagtail.core',
+    )
+else:
+    INSTALLED_APPS += (
+        'wagtail.wagtailsearch',
+        'wagtail.wagtailembeds',
+        'wagtail.wagtailimages',
+        'wagtail.wagtailsites',
+        'wagtail.wagtailusers',
+        'wagtail.wagtailsnippets',
+        'wagtail.wagtaildocs',
+        'wagtail.wagtailredirects',
+        'wagtail.wagtailadmin',
+        'wagtail.wagtailcore',
+    )
 
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'staticfiles')
@@ -86,12 +103,21 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'wagtail.wagtailcore.middleware.SiteMiddleware',
-    'wagtail.wagtailredirects.middleware.RedirectMiddleware',
 )
+if WAGTAIL_VERSION >= (2, 0):
+    MIDDLEWARE_CLASSES += (
+        'wagtail.core.middleware.SiteMiddleware',
+        'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+    )
+else:
+    MIDDLEWARE_CLASSES += (
+        'wagtail.wagtailcore.middleware.SiteMiddleware',
+        'wagtail.wagtailredirects.middleware.RedirectMiddleware',
+    )
+if DJANGO_VERSION >= (2, 0):
+    MIDDLEWARE = MIDDLEWARE_CLASSES
 
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',

--- a/wagtailmenus/settings/base.py
+++ b/wagtailmenus/settings/base.py
@@ -122,7 +122,6 @@ if DJANGO_VERSION >= (2, 0):
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-    'compressor.finders.CompressorFinder',
 )
 
 WAGTAILMENUS_FLAT_MENUS_HANDLE_CHOICES = (

--- a/wagtailmenus/templatetags/menu_tags.py
+++ b/wagtailmenus/templatetags/menu_tags.py
@@ -1,5 +1,9 @@
 from django.template import Library
-from wagtail.wagtailcore.models import Page
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Page
+else:
+    from wagtail.wagtailcore.models import Page
 
 from wagtailmenus import app_settings
 from wagtailmenus.errors import SubMenuUsageError

--- a/wagtailmenus/tests/models/menus.py
+++ b/wagtailmenus/tests/models/menus.py
@@ -1,7 +1,12 @@
 from django.db import models
 from modelcluster.fields import ParentalKey
-from wagtail.wagtailadmin.edit_handlers import (
-    FieldPanel, MultiFieldPanel, PageChooserPanel)
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.admin.edit_handlers import (
+        FieldPanel, MultiFieldPanel, PageChooserPanel)
+else:
+    from wagtail.wagtailadmin.edit_handlers import (
+        FieldPanel, MultiFieldPanel, PageChooserPanel)
 from wagtailmenus.models import (
     SectionMenu, ChildrenMenu, AbstractMainMenu,
     AbstractMainMenuItem, AbstractFlatMenu, AbstractFlatMenuItem)

--- a/wagtailmenus/tests/models/pages.py
+++ b/wagtailmenus/tests/models/pages.py
@@ -1,9 +1,15 @@
 from django.db import models
-
-from wagtail.wagtailadmin.edit_handlers import (
-    FieldPanel, MultiFieldPanel, PublishingPanel
-)
-from wagtail.wagtailcore.models import Page
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.admin.edit_handlers import (
+        FieldPanel, MultiFieldPanel, PublishingPanel
+    )
+    from wagtail.core.models import Page
+else:
+    from wagtail.wagtailadmin.edit_handlers import (
+        FieldPanel, MultiFieldPanel, PublishingPanel
+    )
+    from wagtail.wagtailcore.models import Page
 
 from wagtailmenus.models import MenuPage, AbstractLinkPage
 from .utils import TranslatedField

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -3,9 +3,14 @@ from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
 from django.test import TransactionTestCase, override_settings, modify_settings
 from django_webtest import WebTest
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.admin.edit_handlers import ObjectList, InlinePanel
+    from wagtail.core.models import Page, Site
+else:
+    from wagtail.wagtailadmin.edit_handlers import ObjectList, InlinePanel
+    from wagtail.wagtailcore.models import Page, Site
 
-from wagtail.wagtailadmin.edit_handlers import ObjectList, InlinePanel
-from wagtail.wagtailcore.models import Page, Site
 from wagtailmenus import get_flat_menu_model, get_main_menu_model
 from wagtailmenus.panels import (
     FlatMenuItemsInlinePanel, MainMenuItemsInlinePanel)

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -191,22 +191,9 @@ class TestSuperUser(TransactionTestCase):
         menu_model.edit_handler = ObjectList(menu_model.content_panels)
         response = self.client.get('/admin/wagtailmenus/mainmenu/edit/1/')
 
-    def test_not_condensedinlinepanel(self):
-        self.assertTrue(isinstance(FlatMenuItemsInlinePanel(), InlinePanel))
-        self.assertTrue(isinstance(MainMenuItemsInlinePanel(), InlinePanel))
-
-    @modify_settings(INSTALLED_APPS={'append': 'condensedinlinepanel'})
-    def test_condensedinlinepanel(self):
-        from condensedinlinepanel.edit_handlers import CondensedInlinePanel
-        self.assertTrue(isinstance(FlatMenuItemsInlinePanel(), CondensedInlinePanel))
-        self.assertTrue(isinstance(MainMenuItemsInlinePanel(), CondensedInlinePanel))
-
     def test_mainmenu_edit_multisite(self):
         Site.objects.create(
-            hostname='test2.com', port=80, root_page_id=2,
-            is_default_site=0, site_name="Test site 2")
-        Site.objects.create(
-            hostname='test3.com', port=80, root_page_id=3,
+            id=3, hostname='test3.com', port=80, root_page_id=2,
             is_default_site=0, site_name="Test site 3")
 
         response = self.client.get(
@@ -268,6 +255,21 @@ class TestSuperUser(TransactionTestCase):
         response = self.client.get(
             '/admin/wagtailmenus/flatmenu/copy/1/')
         self.assertEqual(response.status_code, 200)
+
+    def test_panels_are_not_condensedinlinepanels(self):
+        self.assertTrue(isinstance(FlatMenuItemsInlinePanel(), InlinePanel))
+        self.assertTrue(isinstance(MainMenuItemsInlinePanel(), InlinePanel))
+
+    """
+    TODO: Uncomment once wagtail-condensedinlinepanel releases a Wagtail 2.0
+    compatible version
+
+    @modify_settings(INSTALLED_APPS={'append': 'condensedinlinepanel'})
+    def test_panels_are_condensedinlinepanels(self):
+        from condensedinlinepanel.edit_handlers import CondensedInlinePanel
+        self.assertTrue(isinstance(FlatMenuItemsInlinePanel(), CondensedInlinePanel))
+        self.assertTrue(isinstance(MainMenuItemsInlinePanel(), CondensedInlinePanel))
+    """
 
 
 class TestNonSuperUser(TransactionTestCase):

--- a/wagtailmenus/tests/test_commands.py
+++ b/wagtailmenus/tests/test_commands.py
@@ -1,6 +1,11 @@
 from django.test import TestCase
 from django.core.management import call_command
-from wagtail.wagtailcore.models import Site
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Site
+else:
+    # < Wagtail 2.0
+    from wagtail.wagtailcore.models import Site
 
 from wagtailmenus import app_settings
 

--- a/wagtailmenus/tests/test_custom_models.py
+++ b/wagtailmenus/tests/test_custom_models.py
@@ -5,8 +5,11 @@ from bs4 import BeautifulSoup
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase, override_settings
-
-from wagtail.wagtailcore.models import Site
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Site
+else:
+    from wagtail.wagtailcore.models import Site
 from wagtailmenus import get_main_menu_model, get_flat_menu_model
 from wagtailmenus.models import MainMenu, FlatMenu
 from wagtailmenus.tests.models import (

--- a/wagtailmenus/tests/test_hooks.py
+++ b/wagtailmenus/tests/test_hooks.py
@@ -1,8 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
-from django.test import TestCase
-from wagtail.wagtailcore import hooks
 from bs4 import BeautifulSoup
+from django.test import TestCase
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core import hooks
+else:
+    from wagtail.wagtailcore import hooks
 
 
 class TestHooks(TestCase):
@@ -50,7 +54,7 @@ class TestHooks(TestCase):
         def modify_menu_items(
             menu_items, request, parent_context, parent_page, menu_instance,
             original_menu_instance, menu_tag, original_menu_tag, current_level,
-            max_levels, use_specific, current_site, current_page, 
+            max_levels, use_specific, current_site, current_page,
             current_section_root_page, current_page_ancestor_ids,
             apply_active_classes, allow_repeating_parents,
             use_absolute_page_urls

--- a/wagtailmenus/tests/test_menu_classes.py
+++ b/wagtailmenus/tests/test_menu_classes.py
@@ -2,8 +2,12 @@ from __future__ import absolute_import, unicode_literals
 
 from django.test import TestCase
 from django.core.exceptions import ValidationError
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Page
+else:
+    from wagtail.wagtailcore.models import Page
 
-from wagtail.wagtailcore.models import Page
 from wagtailmenus.models import (
     ChildrenMenu, MainMenu, MainMenuItem, FlatMenu, FlatMenuItem)
 

--- a/wagtailmenus/tests/test_menu_rendering.py
+++ b/wagtailmenus/tests/test_menu_rendering.py
@@ -1,9 +1,14 @@
+from bs4 import BeautifulSoup
 from django.test import TestCase, override_settings
-from wagtail.wagtailcore.models import Site
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Site
+else:
+    from wagtail.wagtailcore.models import Site
 from wagtailmenus.errors import SubMenuUsageError
 from wagtailmenus.models import MainMenu, FlatMenu
 from wagtailmenus.templatetags.menu_tags import validate_supplied_values
-from bs4 import BeautifulSoup
+
 
 
 class TestTemplateTags(TestCase):

--- a/wagtailmenus/tests/test_page_models.py
+++ b/wagtailmenus/tests/test_page_models.py
@@ -1,7 +1,11 @@
 from django.test import TestCase
 from django.core.exceptions import ValidationError
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Site
+else:
+    from wagtail.wagtailcore.models import Site
 
-from wagtail.wagtailcore.models import Site
 from wagtailmenus.tests.models import LinkPage
 
 

--- a/wagtailmenus/tests/urls.py
+++ b/wagtailmenus/tests/urls.py
@@ -1,8 +1,13 @@
 from django.conf.urls import include, url
-
 from django.views.generic import TemplateView
-from wagtail.wagtailadmin import urls as wagtailadmin_urls
-from wagtail.wagtailcore import urls as wagtail_urls
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.admin import urls as wagtailadmin_urls
+    from wagtail.core import urls as wagtail_urls
+else:
+    from wagtail.wagtailadmin import urls as wagtailadmin_urls
+    from wagtail.wagtailcore import urls as wagtail_urls
+
 
 urlpatterns = [
     url(r'^admin/', include(wagtailadmin_urls)),

--- a/wagtailmenus/utils/misc.py
+++ b/wagtailmenus/utils/misc.py
@@ -1,4 +1,9 @@
-from wagtail.wagtailcore.models import Page, Site
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Page, Site
+else:
+    from wagtail.wagtailcore.models import Page, Site
+
 from ..models.menuitems import MenuItem
 
 

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -6,11 +6,15 @@ from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
-
-from wagtail.wagtailadmin import messages
-from wagtail.wagtailadmin.edit_handlers import ObjectList, TabbedInterface
-from wagtail.wagtailcore.models import Site
-
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.admin import messages
+    from wagtail.admin.edit_handlers import ObjectList, TabbedInterface
+    from wagtail.core.models import Site
+else:
+    from wagtail.wagtailadmin import messages
+    from wagtail.wagtailadmin.edit_handlers import ObjectList, TabbedInterface
+    from wagtail.wagtailcore.models import Site
 from wagtail.contrib.modeladmin.views import (
     WMABaseView, CreateView, EditView, ModelFormView)
 

--- a/wagtailmenus/wagtail_hooks.py
+++ b/wagtailmenus/wagtail_hooks.py
@@ -2,10 +2,13 @@ from django.conf.urls import url
 from django.contrib.admin.utils import quote
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-
+from wagtail import VERSION as WAGTAIL_VERSION
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core import hooks
+else:
+    from wagtail.wagtailcore import hooks
 from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
 from wagtail.contrib.modeladmin.helpers import ButtonHelper
-from wagtail.wagtailcore import hooks
 
 from . import app_settings, get_main_menu_model, get_flat_menu_model
 from .views import (MainMenuIndexView, MainMenuEditView, FlatMenuCreateView,


### PR DESCRIPTION
Tests are currently passing against the beta release with both Django 1.11 and 2.0.

I don't envisage there being any changes between now and the official release, but I'd like to wait and be sure before merging.

It's unknown at this time whether wagtail-condensedinlinepanel will be updated to support 2.0 any time soon, so I might add a note about that to the installation instructions where it is recommended. 