### PR TITLE
Keep the 'handle' field label when switching to ChoiceField

### DIFF
--- a/wagtailmenus/forms.py
+++ b/wagtailmenus/forms.py
@@ -14,7 +14,9 @@ class FlatMenuAdminForm(WagtailAdminModelForm):
         super().__init__(*args, **kwargs)
         if app_settings.FLAT_MENUS_HANDLE_CHOICES:
             self.fields['handle'] = forms.ChoiceField(
-                choices=app_settings.FLAT_MENUS_HANDLE_CHOICES)
+                label=self.fields['handle'].label,
+                choices=app_settings.FLAT_MENUS_HANDLE_CHOICES
+            )
 
 
 class LinkPageAdminForm(WagtailAdminPageForm):


### PR DESCRIPTION
This really small fix prevents to have the `handle` field label untranslated when it is replaced by a `ChoiceField`.

Thanks by the way for this nice extension!