### PR TITLE
Implement WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ wagtailmenus.sqlite
 # PyCharm
 .idea/
 
+# VSCode
+.vscode/

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@
 * Oliver Bestwalter (obestwalter)
 * Nguyễn Hồng Quân (hongquan)
 * jeromelebleu
+* Joshua C. Jackson (inostia)
 
 
 ## Translators

--- a/docs/source/rendering_menus/template_tag_reference.rst
+++ b/docs/source/rendering_menus/template_tag_reference.rst
@@ -96,6 +96,8 @@ The tag will attempt to add 'active' and 'ancestor' CSS classes to the menu item
 
 You can change the CSS class strings used to indicate 'active' and 'ancestor' statuses by utilising the :ref:`ACTIVE_CLASS` and :ref:`ACTIVE_ANCESTOR_CLASS` settings.
 
+By default, custom links will perform a strict comparison of the ``custom_link`` path and the current path. In this case a ``custom_link`` will never render as an 'ancestor' of a url. You can override this behavior by setting :ref:``CUSTOM_URL_SMART_ACTIVE_CLASSES`` to ``True``.
+
 -----
 
 template
@@ -252,6 +254,8 @@ No         ``bool``             ``False``
 Unlike ``main_menu`` and ``section_menu``, ``flat_menu`` will NOT attempt to add ``'active'`` and ``'ancestor'`` classes to the menu items by default, as this is often not useful. You can override this by adding ``apply_active_classes=true`` to the tag in your template.
 
 You can change the CSS class strings used to indicate 'active' and 'ancestor' statuses by utilising the :ref:`ACTIVE_CLASS` and :ref:`ACTIVE_ANCESTOR_CLASS` settings.
+
+By default, custom links will perform a strict comparison of the ``custom_link`` path and the current path. In this case a ``custom_link`` will never render as an 'ancestor' of a url. You can override this behavior by setting :ref:``CUSTOM_URL_SMART_ACTIVE_CLASSES`` to ``True``.
 
 -----
 
@@ -429,6 +433,8 @@ The tag will add 'active' and 'ancestor' classes to the menu items where applica
 
 You can change the CSS class strings used to indicate 'active' and 'ancestor' statuses by utilising the :ref:`ACTIVE_CLASS` and :ref:`ACTIVE_ANCESTOR_CLASS` settings.
 
+By default, custom links will perform a strict comparison of the ``custom_link`` path and the current path. In this case a ``custom_link`` will never render as an 'ancestor' of a url. You can override this behavior by setting :ref:``CUSTOM_URL_SMART_ACTIVE_CLASSES`` to ``True``.
+
 -----
 
 allow_repeating_parents
@@ -575,6 +581,8 @@ No         ``bool``             ``False``
 Unlike ``main_menu`` and `section_menu``, ``children_menu`` will NOT attempt to add ``'active'`` and ``'ancestor'`` classes to the menu items by default, as this is often not useful. You can override this by adding ``apply_active_classes=true`` to the tag in your template.
 
 You can change the CSS class strings used to indicate 'active' and 'ancestor' statuses by utilising the :ref:`ACTIVE_CLASS` and :ref:`ACTIVE_ANCESTOR_CLASS` settings.
+
+By default, custom links will perform a strict comparison of the ``custom_link`` path and the current path. In this case a ``custom_link`` will never render as an 'ancestor' of a url. You can override this behavior by setting :ref:``CUSTOM_URL_SMART_ACTIVE_CLASSES`` to ``True``.
 
 -----
 

--- a/docs/source/settings_reference.rst
+++ b/docs/source/settings_reference.rst
@@ -327,3 +327,12 @@ When preparing menu items for rendering, wagtailmenus looks for a field, attribu
 Default value: ``3``
 
 Use this to specify the 'depth' value of a project's 'section root' pages. For most Wagtail projects, this should be ``3`` (Root page depth = ``1``, Home page depth = ``2``), but it may well differ, depending on the needs of the project.
+
+.. _CUSTOM_URL_SMART_ACTIVE_CLASSES
+
+``WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default value: ``False``
+
+Set this to ``True`` if a ``custom_link`` path should be assumed to be an ancestor of the current page if it matches the beginning of the current url path. Apply ``WAGTAILMENUS_ACTIVE_ANCESTOR_CLASS`` if applicable.

--- a/wagtailmenus/app_settings.py
+++ b/wagtailmenus/app_settings.py
@@ -204,6 +204,10 @@ class AppSettings:
     def SECTION_MENU_CLASS(self):
         return self.class_from_path_setting('SECTION_MENU_CLASS_PATH')
 
+    @property
+    def CUSTOM_URL_SMART_ACTIVE_CLASSES(self):
+        return self._setting('CUSTOM_URL_SMART_ACTIVE_CLASSES', False)
+
     # TODO: To be removed in v2.8.0
     @property
     def USE_BACKEND_SPECIFIC_TEMPLATES(self):

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -134,12 +134,13 @@ class AbstractMenuItem(models.Model, MenuItem):
         if app_settings.CUSTOM_URL_SMART_ACTIVE_CLASSES:
             # new behaviour
             parsed_url = urlparse(self.link_url)
-            if not parsed_url.netloc:
+            if parsed_url.netloc:
                 # do nothing if the custom link URL has a domain
-                if request_path == parsed_url.path:
-                    active_class = app_settings.ACTIVE_CLASS
-                elif request_path.startswith(parsed_url.path):
-                    active_class = app_settings.ACTIVE_ANCESTOR_CLASS
+                pass
+            elif request_path == parsed_url.path:
+                active_class = app_settings.ACTIVE_CLASS
+            elif request_path.startswith(parsed_url.path):
+                active_class = app_settings.ACTIVE_ANCESTOR_CLASS
 
         elif self.link_url == request_path:
             # previous behaviour

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -510,10 +510,15 @@ class Menu:
                 """
                 This is a `MenuItem` for a custom URL. It can be classed as
                 'active' if the URL matches the request path.
+                If `apps_settings.CUSTOM_URL_SMART_ACTIVE_CLASSES == True`,
+                it may also be classed as 'ancestor' if the current URL is a
+                'child' of the custom link URL.
                 """
-                request_path = self.request.path
-                if apply_active_classes and item.link_url == request_path:
-                    setattr(item, 'active_class', app_settings.ACTIVE_CLASS)
+                if apply_active_classes:
+                    request = self.request
+                    active_class = item.get_active_class_for_request(request)
+                    if active_class:
+                        setattr(item, 'active_class', active_class)
 
             # In case the specific page was fetched during the above operations
             # We'll set `MenuItem.link_page` to that specific page.

--- a/wagtailmenus/settings/base.py
+++ b/wagtailmenus/settings/base.py
@@ -128,4 +128,5 @@ WAGTAILMENUS_FLAT_MENUS_HANDLE_CHOICES = (
     ('contact', 'contact'),
     ('footer', 'footer'),
     ('header-secondary', 'header-secondary'),
+    ('custom-links', 'custom-links'),
 )

--- a/wagtailmenus/tests/fixtures/test.json
+++ b/wagtailmenus/tests/fixtures/test.json
@@ -234,6 +234,18 @@
     }
 },
 {
+    "model": "wagtailmenus.flatmenu",
+    "pk": 4,
+    "fields": {
+        "site": 1,
+        "title": "Custom Links",
+        "handle": "custom-links",
+        "heading": "Custom Links",
+        "max_levels": 1,
+        "use_specific": 1
+    }
+},
+{
     "model": "wagtailmenus.flatmenuitem",
     "pk": 9,
     "fields": {
@@ -269,6 +281,48 @@
         "url_append": "",
         "allow_subnav": false,
         "menu": 3
+    }
+},
+{
+    "model": "wagtailmenus.flatmenuitem",
+    "pk": 15,
+    "fields": {
+        "sort_order": 0,
+        "link_page": null,
+        "link_url": "/people/",
+        "url_append": "#user1",
+        "handle": "",
+        "link_text": "User Directory (hash fragment)",
+        "allow_subnav": false,
+        "menu": 4
+    }
+},
+{
+    "model": "wagtailmenus.flatmenuitem",
+    "pk": 16,
+    "fields": {
+        "sort_order": 1,
+        "link_page": null,
+        "link_url": "/people/",
+        "url_append": "?u=user1",
+        "handle": "",
+        "link_text": "User Directory (query param)",
+        "allow_subnav": false,
+        "menu": 4
+    }
+}, 
+{
+    "model": "wagtailmenus.flatmenuitem",
+    "pk": 17,
+    "fields": {
+        "sort_order": 2,
+        "link_page": null,
+        "link_url": "https://example.com/some-page",
+        "url_append": "",
+        "handle": "",
+        "link_text": "External link with path",
+        "allow_subnav": false,
+        "menu": 4
     }
 },
 {

--- a/wagtailmenus/tests/templates/base.html
+++ b/wagtailmenus/tests/templates/base.html
@@ -6,6 +6,14 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
         <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
         <title>Wagtailmenus Test</title>
+        <style>
+            .active a {
+                color: yellowgreen;
+            }
+            .ancestor a {
+                color: green;
+            }
+        </style>
     </head>
     <body>
         

--- a/wagtailmenus/tests/templates/base.html
+++ b/wagtailmenus/tests/templates/base.html
@@ -62,6 +62,10 @@
                 <div id="nav-footer-absolute-urls">
                     {% flat_menu 'footer' use_absolute_page_urls=True %}
                 </div>
+
+                <div id="custom-links">
+                    {% flat_menu 'custom-links' apply_active_classes=True %}
+                </div>
                 <p class="rkh"><a href="http://www.rkh.co.uk/" target="_blank" title="Web design and development, Leicester">Website by Rock Kitchen Harris</a></p>
             </div>
         </footer>

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -34,9 +34,9 @@ class CMSUsecaseTests(WebTest):
             is_staff=True, is_superuser=True)
 
     def test_copy_footer_menu(self):
-        # First check that there are 3 menus
+        # First check that there are 4 menus
         response = self.app.get(self.base_flatmenu_admin_url, user='test1')
-        assert len(response.context['object_list']) == 3
+        assert len(response.context['object_list']) == 4
 
         site_one = Site.objects.get(id=1)
         site_two = Site.objects.get(id=2)
@@ -51,7 +51,7 @@ class CMSUsecaseTests(WebTest):
         form['site'] = site_two.pk
         response = form.submit().follow()
 
-        assert len(response.context['object_list']) == 4
+        assert len(response.context['object_list']) == 5
         assert '<div class="changelist-filter col3">' in response
 
         # Let's just compare the two menu with the old one

--- a/wagtailmenus/tests/test_menu_rendering.py
+++ b/wagtailmenus/tests/test_menu_rendering.py
@@ -910,6 +910,111 @@ class TestTemplateTags(TestCase):
         """
         self.assertHTMLEqual(menu_html, expected_menu_html)
 
+    @override_settings(WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES=True)
+    def test_smart_custom_links_output(self):
+        response = self.client.get('/about-us/meet-the-team/custom-url/child-page/')
+        soup = BeautifulSoup(response.content, 'html5lib')
+
+        # Assertions to compare rendered HTML against expected HTML
+        menu_html = soup.find(id='nav-footer').decode()
+        expected_menu_html = """
+        <div id="nav-footer">
+            <div class="flat-menu footer with_heading">
+                <h4>Important links</h4>
+                <ul>
+                    <li class="">
+                        <a href="/legal/accessibility/">Accessibility</a>
+                    </li>
+                    <li class="">
+                        <a href="/legal/privacy-policy/">Privacy policy</a>
+                    </li>
+                    <li class="">
+                        <a href="/legal/terms-and-conditions/">Terms and conditions</a>
+                    </li>
+                    <li class="ancestor">
+                        <a href="/about-us/meet-the-team/custom-url/">Meet the team's pets</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        """
+        self.assertHTMLEqual(menu_html, expected_menu_html)
+        
+        response = self.client.get('/people/#user1')
+        soup = BeautifulSoup(response.content, 'html5lib')
+
+        # Assertions to compare rendered HTML against expected HTML
+        menu_html = soup.find(id='custom-links').decode()
+        expected_menu_html = """
+        <div id="custom-links">
+            <div class="flat-menu custom-links with_heading">
+                <h4>Custom Links</h4>
+                <ul>
+                    <li class="active">
+                        <a href="/people/#user1">User Directory (hash fragment)</a>
+                    </li>
+                    <li class="active">
+                        <a href="/people/?u=user1">User Directory (query param)</a>
+                    </li>
+                    <li class="">
+                        <a href="https://example.com/some-page">External link with path</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        """
+        self.assertHTMLEqual(menu_html, expected_menu_html)
+        
+        response = self.client.get('/people/?u=user1')
+        soup = BeautifulSoup(response.content, 'html5lib')
+
+        # Assertions to compare rendered HTML against expected HTML
+        menu_html = soup.find(id='custom-links').decode()
+        expected_menu_html = """
+        <div id="custom-links">
+            <div class="flat-menu custom-links with_heading">
+                <h4>Custom Links</h4>
+                <ul>
+                    <li class="active">
+                        <a href="/people/#user1">User Directory (hash fragment)</a>
+                    </li>
+                    <li class="active">
+                        <a href="/people/?u=user1">User Directory (query param)</a>
+                    </li>
+                    <li class="">
+                        <a href="https://example.com/some-page">External link with path</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        """
+        self.assertHTMLEqual(menu_html, expected_menu_html)
+        
+        response = self.client.get('/some-page/')
+        soup = BeautifulSoup(response.content, 'html5lib')
+
+        # Assertions to compare rendered HTML against expected HTML
+        menu_html = soup.find(id='custom-links').decode()
+        expected_menu_html = """
+        <div id="custom-links">
+            <div class="flat-menu custom-links with_heading">
+                <h4>Custom Links</h4>
+                <ul>
+                    <li class="">
+                        <a href="/people/#user1">User Directory (hash fragment)</a>
+                    </li>
+                    <li class="">
+                        <a href="/people/?u=user1">User Directory (query param)</a>
+                    </li>
+                    <li class="">
+                        <a href="https://example.com/some-page">External link with path</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+        """
+        self.assertHTMLEqual(menu_html, expected_menu_html)
+
     def test_custom_page_menu_output(self):
         response = self.client.get('/custom-url/')
         soup = BeautifulSoup(response.content, 'html5lib')

--- a/wagtailmenus/tests/urls.py
+++ b/wagtailmenus/tests/urls.py
@@ -20,6 +20,12 @@ urlpatterns = [
         TemplateView.as_view(template_name='page.html')),
     url(r'^about-us/meet-the-team/custom-url/$',
         TemplateView.as_view(template_name='page.html')),
+    url(r'^about-us/meet-the-team/custom-url/child-page/$',
+        TemplateView.as_view(template_name='page.html')),
+    url(r'^people/$',
+        TemplateView.as_view(template_name='page.html')),
+    url(r'^some-page/$',
+        TemplateView.as_view(template_name='page.html')),
     url(r'^news-and-events/$',
         TemplateView.as_view(template_name='page.html')),
     # Hijacking the iron-man page to render a different template, that tests


### PR DESCRIPTION
This PR introduces the WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES, which allows a developer to opt-in to highlight `custom_urls` as an ancestor of a url path - and apply WAGTAILMENUS_ACTIVE_ANCESTOR_CLASS if applicable.