### PR TITLE
Fix #222: Deprecate the current active class attribution logic for 'custom URL' menu items

### DIFF
--- a/docs/source/releases/2.8.0.rst
+++ b/docs/source/releases/2.8.0.rst
@@ -16,7 +16,16 @@ Wagtailmenus 2.8 (alpha) release notes
 What's new?
 ===========
 
-TBA
+Smarter 'active class' attribution for menu items that link to custom URLs 
+--------------------------------------------------------------------------
+
+By default, menu items linking to custom URLs are currently only attributed with the 'active' class if their ``link_url`` value matches the path of the current request **exactly**, producing unexpected results when GET parameters or fragments are added to the end of a ``link_url`` value.
+
+A new and improved approach to active class attribution for custom URL links has now been implemented (by Joshua C. Jackson and Andy Babic), which you can enable by adding ``WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES = True`` to your project's settings.
+
+With the new approach, only the 'path' part of the ``link_url`` value is used for comparision with ``request.path``, which produces far more consistent results. The new approach also allows the 'ancestor' class to be attributed to menu items where the ``link_url`` looks like an ancestor of the current request URL. For example, if a menu item's ``link_url`` value is ``'/news/'``, and the request path is ``'/news/boring-news-article/'``, then the menu item will be attributed with the 'ancestor' class.
+
+The previous behaviour is now deprecated in favour of this new approach, and will be removed in version 2.10, with the new approach becoming the default (and only) option.
 
 
 Minor changes & bug fixes 
@@ -28,7 +37,7 @@ TBA
 Deprecations
 ============
 
-TBA
+- The current 'active class' attribution behaviour for menu items linking to custom URLs is deprecated (see above for details). Add ``WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES = True`` to your project's settings to enable the new and improved behaviour and silence the deprecation warning.
 
 
 Upgrade considerations

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import defaultdict, namedtuple
 from types import GeneratorType
 
@@ -21,6 +22,7 @@ from .. import app_settings
 from ..forms import FlatMenuAdminForm
 from ..panels import (
     main_menu_content_panels, flat_menu_content_panels, menu_settings_panels)
+from ..utils.deprecation import RemovedInWagtailMenus210Warning
 from ..utils.misc import get_site_from_request
 from .menuitems import MenuItem
 from .mixins import DefinesSubMenuTemplatesMixin
@@ -28,6 +30,19 @@ from .pages import AbstractLinkPage
 
 
 mark_safe_lazy = lazy(mark_safe, six.text_type)
+
+# TODO: To be removed in v.2.10
+WARNING_MSG = (
+    "The current default 'active' class attribution behaviour for menu items "
+    "that link to custom URLs is deprecated in favour of the smarter approach "
+    "introduced in 2.8. You can use this new behaviour right now by "
+    "adding 'WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES = True' "
+    "to your project's settings (which will also silence this warning). See "
+    "the 2.8 release notes for more info: "
+    "http://wagtailmenus.readthedocs.io/en/stable/releases/2.8.0.html"
+)
+if not app_settings.CUSTOM_URL_SMART_ACTIVE_CLASSES:
+    warnings.warn(WARNING_MSG, category=RemovedInWagtailMenus210Warning)
 
 
 ContextualVals = namedtuple('ContextualVals', (

--- a/wagtailmenus/utils/deprecation.py
+++ b/wagtailmenus/utils/deprecation.py
@@ -5,9 +5,9 @@ class RemovedInWagtailMenus29Warning(DeprecationWarning):
 removed_in_next_version_warning = RemovedInWagtailMenus29Warning
 
 
-class RemovedInWagtailMenus30Warning(PendingDeprecationWarning):
+class RemovedInWagtailMenus210Warning(PendingDeprecationWarning):
     pass
 
 
-class RemovedInWagtailMenus31Warning(PendingDeprecationWarning):
+class RemovedInWagtailMenus211Warning(PendingDeprecationWarning):
     pass


### PR DESCRIPTION
Resolves #222 