### PR TITLE
General tidying and optimisation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ testing_extras = [
     'beautifulsoup4==4.5.1',
     'coverage>=3.7.0',
     'wagtail-condensedinlinepanel==0.3',
-    'mock>=2.0.0'
 ]
 
 documentation_extras = [

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1173,7 +1173,7 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
 
         default_site_menu = None
         for obj in queryset:
-            if obj.site == site:
+            if obj.site_id == site.id:
                 return obj
             if fall_back_to_default_site_menus:
                 default_site_menu = obj

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -899,14 +899,16 @@ class MenuWithMenuItems(ClusterableModel, Menu):
         menu_items = self.get_base_menuitem_queryset()
 
         # Identify which pages to fetch for the top level items
-        page_ids = tuple(obj.link_page_id for obj in menu_items)
+        page_ids = tuple(
+            obj.link_page_id for obj in menu_items if obj.link_page_id
+        )
         page_dict = {}
         if page_ids:
             # We use 'get_base_page_queryset' here, because if hooks are being
             # used to modify page querysets, that should affect the top level
             # items also
             top_level_pages = self.get_base_page_queryset().filter(
-                id__in=(obj.link_page_id for obj in menu_items)
+                id__in=page_ids
             )
             if self.use_specific >= app_settings.USE_SPECIFIC_TOP_LEVEL:
                 """

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -2,7 +2,7 @@ import warnings
 from collections import defaultdict, namedtuple
 from types import GeneratorType
 
-from django.db import models, Q
+from django.db import models
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.template.loader import get_template, select_template
 from django.utils import six
@@ -1154,7 +1154,7 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
         queryset = cls.objects.filter(handle__exact=handle)
         if fall_back_to_default_site_menus:
             queryset = queryset.filter(
-                Q(site=site) | Q(site__is_default_site=True)
+                models.Q(site=site) | models.Q(site__is_default_site=True)
             )
         else:
             queryset = queryset.filter(site=site)

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1163,13 +1163,13 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
     def get_for_site(cls, handle, site, fall_back_to_default_site_menus=False):
         """Get a FlatMenu instance with a matching `handle` for the `site`
         provided - or for the 'default' site if not found."""
-        queryset = cls.objects.filter(handle__exact=handle)
-        if fall_back_to_default_site_menus:
-            queryset = queryset.filter(
-                models.Q(site=site) | models.Q(site__is_default_site=True)
-            )
-        else:
-            queryset = queryset.filter(site=site)
+        site_query = models.Q(site_id=site.id)
+        if(fall_back_to_default_site_menus and not site.is_default_site):
+            default_site_id = cls.get_default_site_id()
+            if default_site_id:
+                site_query |= models.Q(site_id=default_site_id)
+
+        queryset = cls.objects.filter(handle__exact=handle).filter(site_query)
 
         default_site_menu = None
         for obj in queryset:

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -24,10 +24,10 @@ from .pages import AbstractLinkPage
 
 if WAGTAIL_VERSION >= (2, 0):
     from wagtail.core import hooks
-    from wagtail.core.models import Page
+    from wagtail.core.models import Page, Site
 else:
     from wagtail.wagtailcore import hooks
-    from wagtail.wagtailcore.models import Page
+    from wagtail.wagtailcore.models import Page, Site
 
 
 mark_safe_lazy = lazy(mark_safe, six.text_type)
@@ -1087,7 +1087,7 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
     menu_items_relation_setting_name = 'FLAT_MENU_ITEMS_RELATED_NAME'
 
     site = models.ForeignKey(
-        'wagtailcore.Site',
+        Site,
         verbose_name=_('site'),
         db_index=True,
         on_delete=models.CASCADE,
@@ -1151,6 +1151,13 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
             )
         except cls.DoesNotExist:
             return
+
+    @classmethod
+    def get_default_site_id(cls):
+        try:
+            return Site.objects.values('id').get(is_default_site=True)['id']
+        except Site.DoesNotExist:
+            pass
 
     @classmethod
     def get_for_site(cls, handle, site, fall_back_to_default_site_menus=False):

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -1,15 +1,13 @@
 from importlib import reload
+from unittest.mock import call, patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
-from django.test import (
-    TestCase, TransactionTestCase, modify_settings, override_settings
-)
-from mock import call, patch
-
+from django.test import TestCase, TransactionTestCase, override_settings
 from django_webtest import WebTest
 from wagtail import VERSION as WAGTAIL_VERSION
+
 from wagtailmenus import (
     get_flat_menu_model, get_main_menu_model, wagtail_hooks
 )

--- a/wagtailmenus/tests/test_custom_models.py
+++ b/wagtailmenus/tests/test_custom_models.py
@@ -421,9 +421,7 @@ class TestInvalidCustomMenuModels(TestCase):
     def test_invalid_main_menu_items_related_name(self):
         with self.assertRaisesMessage(ImproperlyConfigured, (
             "'invalid_related_name' isn't a valid relationship name for "
-            "accessing menu items from MainMenu. Check that your "
-            "`WAGTAILMENUS_MAIN_MENU_ITEMS_RELATED_NAME` setting matches the "
-            "`related_name` used on your MenuItem model's `ParentalKey` field."
+            "accessing menu items from MainMenu."
         )):
             menu = get_main_menu_model().objects.get(id=1)
             menu.get_menu_items_manager()
@@ -432,9 +430,7 @@ class TestInvalidCustomMenuModels(TestCase):
     def test_invalid_flat_menu_items_related_name(self):
         with self.assertRaisesMessage(ImproperlyConfigured, (
             "'invalid_related_name' isn't a valid relationship name for "
-            "accessing menu items from FlatMenu. Check that your "
-            "`WAGTAILMENUS_FLAT_MENU_ITEMS_RELATED_NAME` setting matches the "
-            "`related_name` used on your MenuItem model's `ParentalKey` field."
+            "accessing menu items from FlatMenu."
         )):
             menu = get_flat_menu_model().objects.get(id=1)
             menu.get_menu_items_manager()

--- a/wagtailmenus/tests/test_flatmenu_class.py
+++ b/wagtailmenus/tests/test_flatmenu_class.py
@@ -34,73 +34,54 @@ class TestGetForSite(FlatMenuTestCase):
     """Unit tests for AbstractFlatMenu.get_for_site()"""
     def setUp(self):
         super().setUp()
-        self.secondary_site = Site.objects.create(
+        self.default_site = self.site
+        self.not_default_site = Site.objects.create(
             hostname='test2.com',
             root_page=Page.objects.all().first(),
             is_default_site=False,
         )
-        self.secondary_site_menus = tuple(
-            self.create_test_menus_for_site(self.secondary_site, count=2)
+        self.not_default_site_menus = tuple(
+            self.create_test_menus_for_site(self.not_default_site)
         )
 
     def test_returns_none_if_no_match_for_supplied_site_and_fall_back_to_default_site_menus_is_false(self):
-        test_handle_value = 'test-3'
-        test_site_value = self.secondary_site
+        test_handle = 'test-1'
 
-        default_site = self.site
-        self.assertTrue(
-            FlatMenu.objects.filter(site=default_site, handle=test_handle_value).exists()
-        )
-        self.assertFalse(
-            FlatMenu.objects.filter(site=test_site_value, handle=test_handle_value).exists()
-        )
+        FlatMenu.objects.get(site=self.not_default_site, handle=test_handle).delete()
 
         with self.assertNumQueries(1):
             result = FlatMenu.get_for_site(
-                handle=test_handle_value,
-                site=test_site_value,
+                handle=test_handle,
+                site=self.not_default_site,
                 fall_back_to_default_site_menus=False
             )
         self.assertIs(result, None)
 
     def test_returns_menu_for_default_site_if_no_match_for_supplied_site_and_fall_back_to_default_site_menus_is_true(self):
-        test_handle_value = 'test-3'
-        test_site_value = self.secondary_site
+        test_handle = 'test-1'
 
-        default_site = Site.objects.get(is_default_site=True)
-        expected_result = FlatMenu.objects.get(site=default_site, handle=test_handle_value)
-        self.assertFalse(
-            FlatMenu.objects.filter(site=test_site_value, handle=test_handle_value).exists()
-        )
+        FlatMenu.objects.get(site=self.not_default_site, handle=test_handle).delete()
 
-        # Because the supplied site isn't the default site, get_default_site_id()
-        # will be first be called to identify the default site
-        with self.assertNumQueries(2):
+        expected_result = FlatMenu.objects.get(
+            site=self.default_site, handle=test_handle)
+
+        with self.assertNumQueries(1):
             result = FlatMenu.get_for_site(
-                handle=test_handle_value,
-                site=test_site_value,
+                handle=test_handle,
+                site=self.not_default_site,
                 fall_back_to_default_site_menus=True
             )
         self.assertEqual(result, expected_result)
 
-    def test_no_additional_queries_made_if_the_supplied_site_is_the_default_site(self):
-        test_handle_value = 'test-1'
-        default_site = self.site
-        self.assertTrue(default_site.is_default_site)
-
-        with self.assertNumQueries(1):
-            FlatMenu.get_for_site(
-                handle=test_handle_value,
-                site=default_site,
-                fall_back_to_default_site_menus=True
-            )
-
-        with self.assertNumQueries(1):
-            FlatMenu.get_for_site(
-                handle=test_handle_value,
-                site=default_site,
-                fall_back_to_default_site_menus=False
-            )
+    def test_returns_provided_site_matches_over_default_site_matches(self):
+        for handle in ('test-1', 'test-2', 'test-3'):
+            with self.assertNumQueries(1):
+                result = FlatMenu.get_for_site(
+                    handle=handle,
+                    site=self.not_default_site,
+                    fall_back_to_default_site_menus=True
+                )
+            self.assertEqual(result.site_id, self.not_default_site.id)
 
 
 class TestGetSubMenuTemplateNames(

--- a/wagtailmenus/tests/test_flatmenu_class.py
+++ b/wagtailmenus/tests/test_flatmenu_class.py
@@ -10,21 +10,21 @@ Site = utils.get_site_model()
 class FlatMenuTestCase(TestCase):
     """A base TestCase class for testing FlatMenu model class methods"""
 
-    def setUp(self):
-        self.site = Site.objects.get()
-        self.menus = (
-            FlatMenu.objects.create(
-                site=self.site, handle='test-1', title="Test Menu 1"
-            ),
-            FlatMenu.objects.create(
-                site=self.site, handle='test-2', title="Test Menu 2"
-            ),
-            FlatMenu.objects.create(
-                site=self.site, handle='test-3', title="Test Menu 3"
+    @staticmethod
+    def create_test_menus_for_site(site, count=3, set_option_vals=False):
+        for i in range(1, count + 1):
+            obj = FlatMenu.objects.create(
+                site=site, handle='test-%s' % i, title='Test Menu %s' % i
             )
+            if set_option_vals:
+                obj._option_vals = utils.make_optionvals_instance()
+            yield obj
+
+    def setUp(self):
+        self.site = Site.objects.get(is_default_site=True)
+        self.menus = tuple(
+            self.create_test_menus_for_site(self.site, set_option_vals=True)
         )
-        for menu in self.menus:
-            menu._option_vals = utils.make_optionvals_instance()
 
     def get_test_menu_instance(self):
         return self.menus[0]

--- a/wagtailmenus/tests/test_flatmenu_class.py
+++ b/wagtailmenus/tests/test_flatmenu_class.py
@@ -47,7 +47,7 @@ class TestGetForSite(FlatMenuTestCase):
     def test_returns_none_if_no_match_for_supplied_site_and_fall_back_to_default_site_menus_is_false(self):
         test_handle = 'test-1'
 
-        FlatMenu.objects.get(site=self.not_default_site, handle=test_handle).delete()
+        FlatMenu.objects.filter(site=self.not_default_site, handle=test_handle).delete()
 
         with self.assertNumQueries(1):
             result = FlatMenu.get_for_site(
@@ -60,7 +60,7 @@ class TestGetForSite(FlatMenuTestCase):
     def test_returns_menu_for_default_site_if_no_match_for_supplied_site_and_fall_back_to_default_site_menus_is_true(self):
         test_handle = 'test-1'
 
-        FlatMenu.objects.get(site=self.not_default_site, handle=test_handle).delete()
+        FlatMenu.objects.filter(site=self.not_default_site, handle=test_handle).delete()
 
         expected_result = FlatMenu.objects.get(
             site=self.default_site, handle=test_handle)

--- a/wagtailmenus/tests/test_flatmenu_class.py
+++ b/wagtailmenus/tests/test_flatmenu_class.py
@@ -30,6 +30,79 @@ class FlatMenuTestCase(TestCase):
         return self.menus[0]
 
 
+class TestGetForSite(FlatMenuTestCase):
+    """Unit tests for AbstractFlatMenu.get_for_site()"""
+    def setUp(self):
+        super().setUp()
+        self.secondary_site = Site.objects.create(
+            hostname='test2.com',
+            root_page=Page.objects.all().first(),
+            is_default_site=False,
+        )
+        self.secondary_site_menus = tuple(
+            self.create_test_menus_for_site(self.secondary_site, count=2)
+        )
+
+    def test_returns_none_if_no_match_for_supplied_site_and_fall_back_to_default_site_menus_is_false(self):
+        test_handle_value = 'test-3'
+        test_site_value = self.secondary_site
+
+        default_site = self.site
+        self.assertTrue(
+            FlatMenu.objects.filter(site=default_site, handle=test_handle_value).exists()
+        )
+        self.assertFalse(
+            FlatMenu.objects.filter(site=test_site_value, handle=test_handle_value).exists()
+        )
+
+        with self.assertNumQueries(1):
+            result = FlatMenu.get_for_site(
+                handle=test_handle_value,
+                site=test_site_value,
+                fall_back_to_default_site_menus=False
+            )
+        self.assertIs(result, None)
+
+    def test_returns_menu_for_default_site_if_no_match_for_supplied_site_and_fall_back_to_default_site_menus_is_true(self):
+        test_handle_value = 'test-3'
+        test_site_value = self.secondary_site
+
+        default_site = Site.objects.get(is_default_site=True)
+        expected_result = FlatMenu.objects.get(site=default_site, handle=test_handle_value)
+        self.assertFalse(
+            FlatMenu.objects.filter(site=test_site_value, handle=test_handle_value).exists()
+        )
+
+        # Because the supplied site isn't the default site, get_default_site_id()
+        # will be first be called to identify the default site
+        with self.assertNumQueries(2):
+            result = FlatMenu.get_for_site(
+                handle=test_handle_value,
+                site=test_site_value,
+                fall_back_to_default_site_menus=True
+            )
+        self.assertEqual(result, expected_result)
+
+    def test_no_additional_queries_made_if_the_supplied_site_is_the_default_site(self):
+        test_handle_value = 'test-1'
+        default_site = self.site
+        self.assertTrue(default_site.is_default_site)
+
+        with self.assertNumQueries(1):
+            FlatMenu.get_for_site(
+                handle=test_handle_value,
+                site=default_site,
+                fall_back_to_default_site_menus=True
+            )
+
+        with self.assertNumQueries(1):
+            FlatMenu.get_for_site(
+                handle=test_handle_value,
+                site=default_site,
+                fall_back_to_default_site_menus=False
+            )
+
+
 class TestGetSubMenuTemplateNames(
     FlatMenuTestCase, base.GetSubMenuTemplateNamesMethodTestCase
 ):

--- a/wagtailmenus/tests/test_mainmenu_class.py
+++ b/wagtailmenus/tests/test_mainmenu_class.py
@@ -61,7 +61,7 @@ class TestTopLevelItems(MainMenuTestCase):
             for item in menu.top_level_items:
                 assert item.link_page is None or type(item.link_page) is not Page
 
-    def test_method_makes_only_one_query_when_no_menu_items_link_to_pages(self):
+    def test_method_initiates_one_query_when_no_menu_items_link_to_pages(self):
         # First, let's replace any menu items that link to pages with links
         # to custom urls
         for i, item in enumerate(
@@ -76,8 +76,8 @@ class TestTopLevelItems(MainMenuTestCase):
         with self.assertNumQueries(1):
             menu.get_top_level_items()
 
-    def test_method_makes_only_two_queries_when_basic_page_data_is_required(self):
-        menu = MainMenu.objects.get(pk=1)
+    def test_method_initiates_two_queries_when_vanilla_page_data_is_required(self, menu_obj=None):
+        menu = menu_obj or MainMenu.objects.get(pk=1)
         menu.use_specific = app_settings.USE_SPECIFIC_AUTO
         with self.assertNumQueries(2):
             menu.get_top_level_items()

--- a/wagtailmenus/tests/test_mainmenu_class.py
+++ b/wagtailmenus/tests/test_mainmenu_class.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from wagtailmenus import app_settings
 from wagtailmenus.models import MainMenu
 from wagtailmenus.tests import base, utils
 
@@ -31,7 +32,7 @@ class TestTopLevelItems(MainMenuTestCase):
         # This menu has a `use_specific` value of 1 (AUTO)
         self.assertEqual(menu.use_specific, 1)
 
-        # So, the top-level items it return should all just be custom links
+        # So, the top-level items it returns should all just be custom links
         # or have a `link_page` that is just a vanilla Page object.
         for item in menu.top_level_items:
             self.assertTrue(item.link_page is None or type(item.link_page) is Page)
@@ -59,6 +60,27 @@ class TestTopLevelItems(MainMenuTestCase):
         with self.assertNumQueries(0):
             for item in menu.top_level_items:
                 assert item.link_page is None or type(item.link_page) is not Page
+
+    def test_method_makes_only_one_query_when_no_menu_items_link_to_pages(self):
+        # First, let's replace any menu items that link to pages with links
+        # to custom urls
+        for i, item in enumerate(
+            MainMenu.objects.get(pk=1).get_menu_items_manager().all()
+        ):
+            if item.link_page_id:
+                item.link_page = None
+                item.link_url = '/test/{}/'.format(i)
+                item.save()
+
+        menu = MainMenu.objects.get(pk=1)
+        with self.assertNumQueries(1):
+            menu.get_top_level_items()
+
+    def test_method_makes_only_two_queries_when_basic_page_data_is_required(self):
+        menu = MainMenu.objects.get(pk=1)
+        menu.use_specific = app_settings.USE_SPECIFIC_AUTO
+        with self.assertNumQueries(2):
+            menu.get_top_level_items()
 
 
 class TestPagesForDisplay(MainMenuTestCase):


### PR DESCRIPTION
- Replaces `get_menu_items_manager()` on `AbstractMainMenu` and `AbstractFlatMenu` with a generic implmentation on `MenuWithMenuItems`
- In `MenuWithMenuItems.get_top_level_items()` eliminate the unnecessary 'values_list()' when fetching page data, and only make additional queries if at least one menu items links to a page
- In `AbstractFlatMenu.get_for_site()` only ever use a single query to identify a suitable menu instance (instead of a potential 3)