### PR TITLE
Housekeeping/2.10a

### DIFF
--- a/docs/source/releases/2.10.0.rst
+++ b/docs/source/releases/2.10.0.rst
@@ -1,0 +1,37 @@
+=======================================
+Wagtailmenus 2.10 (alpha) release notes
+=======================================
+
+.. NOTE ::
+    
+    Wagtailmenus 2.10 is in the alpha stage of development. Any changes
+    detailed below are subject to change before the final 2.10 release.
+
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+What's new?
+===========
+
+TBA
+
+
+Minor changes & bug fixes 
+=========================
+
+TBA
+
+
+Deprecations
+============
+
+TBA
+
+
+Upgrade considerations
+======================
+
+TBA

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -5,6 +5,7 @@ Release notes
 .. toctree::
     :maxdepth: 1
 
+    2.10.0
     2.9.0
     2.8.0
     2.7.1

--- a/wagtailmenus/__init__.py
+++ b/wagtailmenus/__init__.py
@@ -2,7 +2,7 @@ from wagtailmenus.utils.version import get_version, get_stable_branch_name
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (2, 9, 0, 'final', 0)
+VERSION = (2, 10, 0, 'alpha', 0)
 __version__ = get_version(VERSION)
 stable_branch_name = get_stable_branch_name(VERSION)
 

--- a/wagtailmenus/app_settings.py
+++ b/wagtailmenus/app_settings.py
@@ -205,10 +205,6 @@ class AppSettings:
         return self.class_from_path_setting('SECTION_MENU_CLASS_PATH')
 
     @property
-    def CUSTOM_URL_SMART_ACTIVE_CLASSES(self):
-        return self._setting('CUSTOM_URL_SMART_ACTIVE_CLASSES', False)
-
-    @property
     def MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN(self):
         return self._setting('MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN', True)
 

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -128,22 +128,20 @@ class AbstractMenuItem(models.Model, MenuItem):
         super().clean(*args, **kwargs)
 
     def get_active_class_for_request(self, request=None):
-        # Returns the 'active_class' for a custom link item.
-        if app_settings.CUSTOM_URL_SMART_ACTIVE_CLASSES:
-            # new behaviour
-            parsed_url = urlparse(self.link_url)
-            if parsed_url.netloc:
-                return ''
-            if request.path == parsed_url.path:
-                return app_settings.ACTIVE_CLASS
-            if (
-                request.path.startswith(parsed_url.path) and
-                parsed_url.path != '/'
-            ):
-                return app_settings.ACTIVE_ANCESTOR_CLASS
-        if self.link_url == request.path:
-            # previous behaviour
+        """
+        Return the most appropriate 'active_class' for this menu item (only
+        used when 'link_url' is used instead of 'link_page').
+        """
+        parsed_url = urlparse(self.link_url)
+        if parsed_url.netloc:
+            return ''
+        if request.path == parsed_url.path:
             return app_settings.ACTIVE_CLASS
+        if (
+            request.path.startswith(parsed_url.path) and
+            parsed_url.path != '/'
+        ):
+            return app_settings.ACTIVE_ANCESTOR_CLASS
         return ''
 
     def __str__(self):

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1,4 +1,3 @@
-import warnings
 from collections import defaultdict, namedtuple
 from types import GeneratorType
 
@@ -17,7 +16,6 @@ from .. import app_settings
 from ..forms import FlatMenuAdminForm
 from ..panels import (
     main_menu_content_panels, flat_menu_content_panels, menu_settings_panels)
-from ..utils.deprecation import RemovedInWagtailMenus210Warning
 from ..utils.misc import get_site_from_request
 from .menuitems import MenuItem
 from .mixins import DefinesSubMenuTemplatesMixin
@@ -32,20 +30,6 @@ else:
 
 
 mark_safe_lazy = lazy(mark_safe, six.text_type)
-
-# TODO: To be removed in v.2.10
-WARNING_MSG = (
-    "The current default 'active' class attribution behaviour for menu items "
-    "that link to custom URLs is deprecated in favour of the smarter approach "
-    "introduced in 2.8. You can use this new behaviour right now by "
-    "adding 'WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES = True' "
-    "to your project's settings (which will also silence this warning). See "
-    "the 2.8 release notes for more info: "
-    "http://wagtailmenus.readthedocs.io/en/stable/releases/2.8.0.html"
-)
-if not app_settings.CUSTOM_URL_SMART_ACTIVE_CLASSES:
-    warnings.warn(WARNING_MSG, category=RemovedInWagtailMenus210Warning)
-
 
 ContextualVals = namedtuple('ContextualVals', (
     'parent_context', 'request', 'current_site', 'current_level',
@@ -506,9 +490,8 @@ class Menu:
                 """
                 This is a `MenuItem` for a custom URL. If can be classed as
                 'active' if the URL matches the path of the current request,
-                or (if `apps_settings.CUSTOM_URL_SMART_ACTIVE_CLASSES == True`)
-                as the 'ancestor of the current page' if that looks to be the
-                case.
+                or as the 'ancestor of the current page' if that looks to be
+                the case.
                 """
                 if apply_active_classes:
                     active_class = item.get_active_class_for_request(

--- a/wagtailmenus/tests/test_menu_items.py
+++ b/wagtailmenus/tests/test_menu_items.py
@@ -104,8 +104,7 @@ class TestFlatMenuItemGeneralMethods(MenuItemModelTestMixin, TestCase):
 
 class TestMenuItemsForRequest(TestCase):
     """
-    Tests active classes rendered for menu items where
-    `WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES == False`
+    Tests active classes rendered for menu items
     """
     def setUp(self):
         self.rf = RequestFactory()
@@ -117,21 +116,6 @@ class TestMenuItemsForRequest(TestCase):
 
         active_class = menu_item.get_active_class_for_request(request)
         self.assertEqual(active_class, app_settings.ACTIVE_CLASS)
-
-    def test_menu_item_with_query_params(self):
-        menu_item = AbstractMenuItem()
-        menu_item.link_url = '/some-page/?some_param=foo'
-        request = self.rf.get('/some-page/')
-
-        active_class = menu_item.get_active_class_for_request(request)
-        self.assertEqual(active_class, '')
-
-
-@override_settings(WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES=True)
-class TestMenuItemsForRequestWithSmartClasses(TestCase):
-
-    def setUp(self):
-        self.rf = RequestFactory()
 
     def test_menu_item_with_query_params(self):
         menu_item = AbstractMenuItem()

--- a/wagtailmenus/utils/deprecation.py
+++ b/wagtailmenus/utils/deprecation.py
@@ -1,13 +1,13 @@
-class RemovedInWagtailMenus29Warning(DeprecationWarning):
+class RemovedInWagtailMenus211Warning(DeprecationWarning):
     pass
 
 
-removed_in_next_version_warning = RemovedInWagtailMenus29Warning
+removed_in_next_version_warning = RemovedInWagtailMenus211Warning
 
 
-class RemovedInWagtailMenus210Warning(PendingDeprecationWarning):
+class RemovedInWagtailMenus212Warning(PendingDeprecationWarning):
     pass
 
 
-class RemovedInWagtailMenus211Warning(PendingDeprecationWarning):
+class RemovedInWagtailMenus213Warning(PendingDeprecationWarning):
     pass


### PR DESCRIPTION
- Bump version to 2.10a
- Add release notes
- Removed all references to WAGTAILMENUS_CUSTOM_URL_SMART_ACTIVE_CLASSES setting and made 'smart active classes' behaviour the default/only behaviour in MenuItem. get_active_class_for_request()