### PR TITLE
Restore wagtail-condensedinlinepanel integration tests now that a Wagtail.2.0 compatible version has been released

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -125,19 +125,25 @@ Installing ``wagtail-condensedinlinepanel``
 
 Although doing so is entirely optional, for an all-round better menu editing experience, we recommend using wagtailmenus together with `wagtail-condensedinlinepanel <https://github.com/wagtail/wagtail-condensedinlinepanel>`_.
 
-.. NOTE::
-    ``wagtail-condensedinlinepanel`` hasn't yet released a version compatible with Wagtail 2.0 (you'll have to wait for version ``0.5`` that!). If you're using an earlier version of Wagtail, the latest version of wagtail-condensedinlinepanel (``0.4.2``) should work nicely for you.
-
 ``wagtail-condensedinlinepanel`` offers a React-powered alternative to Wagtail's built-in ``InlinePanel`` with some great extra features that make it perfect for managing menu items; including drag-and-drop reordering and the ability to add new items at any position. 
 
 If you'd like to give it a try, follow the installation instructions below, and wagtailmenus will automatically use the app's ``CollapsedInlinePanel`` class.
 
 
-1.  Install the package using pip: 
+1.  Install the package using pip.
+
+    If your project uses Wagtail ``2.0`` or later, run: 
 
     .. code-block:: console
 
-        pip install wagtail-condensedinlinepanel>=0.4
+        pip install wagtail-condensedinlinepanel==0.5.0
+
+    Otherwise, run:
+
+    .. code-block:: console
+
+        pip install wagtail-condensedinlinepanel==0.4.2
+
 
 2.  Add ``condensedinlinepanel`` to the ``INSTALLED_APPS`` setting in your
     project settings:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ testing_extras = [
     'django-webtest==1.9.2',
     'beautifulsoup4==4.5.1',
     'coverage>=3.7.0',
-    'wagtail-condensedinlinepanel==0.3',
+    'wagtail-condensedinlinepanel==0.4',
 ]
 
 documentation_extras = [

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ testing_extras = [
     'django-webtest==1.9.2',
     'beautifulsoup4==4.5.1',
     'coverage>=3.7.0',
-    'wagtail-condensedinlinepanel==0.4',
+    'wagtail-condensedinlinepanel==0.4.2',
 ]
 
 documentation_extras = [

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps =
     wt112: wagtail>=1.12,<1.13
     wt113: wagtail>=1.13,<2.0
     wt2: wagtail>=2.0,<2.1
-    wt2: wagtail-condensedinlinepanel==5.0
+    wt2: wagtail-condensedinlinepanel>=5.0,<6.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,3 +23,4 @@ deps =
     wt112: wagtail>=1.12,<1.13
     wt113: wagtail>=1.13,<2.0
     wt2: wagtail>=2.0,<2.1
+    wt2: wagtail-condensedinlinepanel==5.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps =
     wt112: wagtail>=1.12,<1.13
     wt113: wagtail>=1.13,<2.0
     wt2: wagtail>=2.0,<2.1
-    wt2: wagtail-condensedinlinepanel>=5.0,<6.0
+    wt2: wagtail-condensedinlinepanel>=5.0.0,<6.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps =
     wt112: wagtail>=1.12,<1.13
     wt113: wagtail>=1.13,<2.0
     wt2: wagtail>=2.0,<2.1
-    wt2: wagtail-condensedinlinepanel>=5.0.0,<6.0
+    wt2: wagtail-condensedinlinepanel==5.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,4 +23,4 @@ deps =
     wt112: wagtail>=1.12,<1.13
     wt113: wagtail>=1.13,<2.0
     wt2: wagtail>=2.0,<2.1
-    wt2: wagtail-condensedinlinepanel==5.0.0
+    wt2: wagtail-condensedinlinepanel>=0.5,<0.6

--- a/wagtailmenus/tests/test_backend.py
+++ b/wagtailmenus/tests/test_backend.py
@@ -4,7 +4,8 @@ from unittest.mock import call, patch
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType
-from django.test import TestCase, TransactionTestCase, override_settings
+from django.test import TestCase, TransactionTestCase, override_settings, \
+    modify_settings
 from django_webtest import WebTest
 from wagtail import VERSION as WAGTAIL_VERSION
 
@@ -265,16 +266,11 @@ class TestSuperUser(TransactionTestCase):
         self.assertTrue(isinstance(FlatMenuItemsInlinePanel(), InlinePanel))
         self.assertTrue(isinstance(MainMenuItemsInlinePanel(), InlinePanel))
 
-    """
-    TODO: Uncomment once wagtail-condensedinlinepanel releases a Wagtail 2.0
-    compatible version
-
     @modify_settings(INSTALLED_APPS={'append': 'condensedinlinepanel'})
     def test_panels_are_condensedinlinepanels(self):
         from condensedinlinepanel.edit_handlers import CondensedInlinePanel
         self.assertTrue(isinstance(FlatMenuItemsInlinePanel(), CondensedInlinePanel))
         self.assertTrue(isinstance(MainMenuItemsInlinePanel(), CondensedInlinePanel))
-    """
 
 
 class TestNonSuperUser(TransactionTestCase):


### PR DESCRIPTION
Related issue: #237 

- [x]  Update test config to use wagtail-condensedinlinepanel 0.4.0 for most test environments, and 0.5.0 for the wagtail 2 one.
- [x]  Restore the basic wagtail-condensedinlinepanel integrations tests
- [x]  Remove the current note from the installation docs about the apps compatibility with wagtail 2.0 and amend installation instructions

