### PR TITLE
Improvements to 'app settings' implementation

### DIFF
--- a/docs/source/releases/2.10.0.rst
+++ b/docs/source/releases/2.10.0.rst
@@ -13,25 +13,69 @@ Wagtailmenus 2.10 (alpha) release notes
     :depth: 1
 
 
-What's new?
-===========
-
-TBA
-
-
 Minor changes & bug fixes 
 =========================
 
-TBA
-
-
-Deprecations
-============
-
-TBA
+- Optimised ``MenuWithMenuItems.get_top_level_items()`` and ``AbstractFlatMenu.get_for_site()`` to use fewer database queries.
+- Configured ``sphinxcontrib.spelling`` and used to correct spelling errors in docs.
+- Updated testing and documentation dependencies.
 
 
 Upgrade considerations
 ======================
 
-TBA
+``FLAT_MENU_MODEL_CLASS`` has been removed from app_settings
+------------------------------------------------------------
+
+If you're referencing ``FLAT_MENU_MODEL_CLASS`` from ``wagtailmenus.app_settings`` anywhere in your project, you'll need to change your code to use the module's new get_model() method instead.
+
+For example, you'd replace this:
+
+.. code-block:: python
+
+    from wagtailmenus import app_settings
+
+    model = app_settings.FLAT_MENU_MODEL_CLASS
+
+With this:
+
+.. code-block:: python
+
+    from wagtailmenus import app_settings
+
+    model = app_settings.get_model('FLAT_MENU_MODEL')
+
+
+``MAIN_MENU_MODEL_CLASS`` has been removed from app_settings
+------------------------------------------------------------
+
+If you're referencing ``MAIN_MENU_MODEL_CLASS`` from ``wagtailmenus.app_settings`` anywhere in your project, you'll need to change your code to use the module's new get_model() method instead.
+
+For example, you'd replace this:
+
+.. code-block:: python
+
+    from wagtailmenus import app_settings
+
+    model = app_settings.MAIN_MENU_MODEL_CLASS
+
+With this:
+
+.. code-block:: python
+
+    from wagtailmenus import app_settings
+
+    model = app_settings.get_model('MAIN_MENU_MODEL')
+
+
+Some other app settings values have moved ``wagtailmenus.constants``
+--------------------------------------------------------------------
+
+The following values have been moved from ``wagtailmenus.app_settings`` to a new ``wagtailmenus.constants`` module:
+
+- ``USE_SPECIFIC_OFF``
+- ``USE_SPECIFIC_AUTO``
+- ``USE_SPECIFIC_TOP_LEVEL``
+- ``USE_SPECIFIC_ALWAYS``
+- ``USE_SPECIFIC_CHOICES``
+- ``MAX_LEVELS_CHOICES``

--- a/wagtailmenus/__init__.py
+++ b/wagtailmenus/__init__.py
@@ -16,8 +16,8 @@ def get_main_menu_model_string():
     main menu model (such as in foreign keys), but the model itself is not
     required.
     """
-    from wagtailmenus import app_settings
-    return app_settings.MAIN_MENU_MODEL
+    import wagtailmenus.app_settings
+    return wagtailmenus.app_settings.MAIN_MENU_MODEL
 
 
 def get_flat_menu_model_string():
@@ -27,8 +27,8 @@ def get_flat_menu_model_string():
     flat menu model (such as in foreign keys), but the model itself is not
     required.
     """
-    from wagtailmenus import app_settings
-    return app_settings.FLAT_MENU_MODEL
+    import wagtailmenus.app_settings
+    return wagtailmenus.app_settings.FLAT_MENU_MODEL
 
 
 def get_main_menu_model():
@@ -38,8 +38,8 @@ def get_main_menu_model():
     Defaults to the standard :class:`~wagtailmenus.models.MainMenu` model
     if no custom model is defined.
     """
-    from wagtailmenus import app_settings
-    return app_settings.MAIN_MENU_MODEL_CLASS
+    import wagtailmenus.app_settings
+    return wagtailmenus.app_settings.get_model('MAIN_MENU_MODEL')
 
 
 def get_flat_menu_model():
@@ -49,5 +49,5 @@ def get_flat_menu_model():
     Defaults to the standard :class:`~wagtailmenus.models.FlatMenu` model
     if no custom model is defined.
     """
-    from wagtailmenus import app_settings
-    return app_settings.FLAT_MENU_MODEL_CLASS
+    import wagtailmenus.app_settings
+    return wagtailmenus.app_settings.get_model('FLAT_MENU_MODEL')

--- a/wagtailmenus/app_settings.py
+++ b/wagtailmenus/app_settings.py
@@ -1,219 +1,40 @@
-from django.utils.translation import ugettext_lazy as _
+import sys
+from wagtailmenus.constants import USE_SPECIFIC_AUTO
+from wagtailmenus.utils.conf import AppSettings
 
+# All supported app settings must be added to the following dictionary
+defaults = dict(
+    ACTIVE_CLASS='active',
+    ADD_EDITOR_OVERRIDE_STYLES=True,
+    ACTIVE_ANCESTOR_CLASS='ancestor',
+    MAINMENU_MENU_ICON='list-ol',
+    FLATMENU_MENU_ICON='list-ol',
+    USE_CONDENSEDINLINEPANEL=True,
+    SITE_SPECIFIC_TEMPLATE_DIRS=False,
+    SECTION_ROOT_DEPTH=3,
+    GUESS_TREE_POSITION_FROM_PATH=True,
+    FLAT_MENUS_FALL_BACK_TO_DEFAULT_SITE_MENUS=False,
+    DEFAULT_MAIN_MENU_TEMPLATE='menus/main_menu.html',
+    DEFAULT_FLAT_MENU_TEMPLATE='menus/flat_menu.html',
+    DEFAULT_SECTION_MENU_TEMPLATE='menus/section_menu.html',
+    DEFAULT_CHILDREN_MENU_TEMPLATE='menus/children_menu.html',
+    DEFAULT_SUB_MENU_TEMPLATE='menus/sub_menu.html',
+    DEFAULT_SECTION_MENU_MAX_LEVELS=2,
+    DEFAULT_CHILDREN_MENU_MAX_LEVELS=1,
+    DEFAULT_SECTION_MENU_USE_SPECIFIC=USE_SPECIFIC_AUTO,
+    DEFAULT_CHILDREN_MENU_USE_SPECIFIC=USE_SPECIFIC_AUTO,
+    PAGE_FIELD_FOR_MENU_ITEM_TEXT='title',
+    MAIN_MENU_MODEL='wagtailmenus.MainMenu',
+    FLAT_MENU_MODEL='wagtailmenus.FlatMenu',
+    MAIN_MENU_ITEMS_RELATED_NAME='menu_items',
+    FLAT_MENU_ITEMS_RELATED_NAME='menu_items',
+    FLAT_MENUS_HANDLE_CHOICES=None,
+    CHILDREN_MENU_CLASS_PATH='wagtailmenus.models.ChildrenMenu',
+    SECTION_MENU_CLASS_PATH='wagtailmenus.models.SectionMenu',
+    MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN=True,
+    MAIN_MENU_MODELADMIN_CLASS='wagtailmenus.modeladmin.MainMenuAdmin',
+    FLAT_MENUS_EDITABLE_IN_WAGTAILADMIN=True,
+    FLAT_MENU_MODELADMIN_CLASS='wagtailmenus.modeladmin.FlatMenuAdmin',
+)
 
-class AppSettings:
-    """Props to django-allauth for the inspiration"""
-
-    USE_SPECIFIC_OFF = 0
-    USE_SPECIFIC_AUTO = 1
-    USE_SPECIFIC_TOP_LEVEL = 2
-    USE_SPECIFIC_ALWAYS = 3
-    USE_SPECIFIC_CHOICES = (
-        (USE_SPECIFIC_OFF, _("Off (most efficient)")),
-        (USE_SPECIFIC_AUTO, _("Auto")),
-        (USE_SPECIFIC_TOP_LEVEL, _("Top level")),
-        (USE_SPECIFIC_ALWAYS, _("Always (least efficient)")),
-    )
-    MAX_LEVELS_CHOICES = (
-        (1, _('1: No sub-navigation (flat)')),
-        (2, _('2: Allow 1 level of sub-navigation')),
-        (3, _('3: Allow 2 levels of sub-navigation')),
-        (4, _('4: Allow 3 levels of sub-navigation')),
-    )
-
-    def __init__(self, prefix):
-        from django.conf import settings
-        self._prefix = prefix
-        self._settings = settings
-
-    def _setting(self, name, default=None):
-        return getattr(self._settings, self._prefix + name, default)
-
-    def class_from_path_setting(self, path_setting_name):
-        from importlib import import_module
-        from django.core.exceptions import ImproperlyConfigured
-        try:
-            import_path = getattr(self, path_setting_name)
-            module_path, class_name = import_path.rsplit(".", 1)
-            return getattr(import_module(module_path), class_name)
-        except(ImportError, ValueError):
-            raise ImproperlyConfigured(
-                "'%s' is not a valid import path. %s%s must be a full "
-                "dotted python import path e.g. 'project.app.file.Class'" %
-                (import_path, self._prefix, path_setting_name)
-            )
-
-    def model_from_path_setting(self, path_setting_name):
-        from django.apps import apps
-        from django.core.exceptions import ImproperlyConfigured
-        model_name = getattr(self, path_setting_name)
-        try:
-            return apps.get_model(model_name)
-        except ValueError:
-            raise ImproperlyConfigured(
-                "%s%s must be of the form 'app_label.model_name'" %
-                (self._prefix, path_setting_name)
-            )
-        except LookupError:
-            raise ImproperlyConfigured(
-                "%s%s refers to model '%s' that has not been installed" %
-                (self._prefix, path_setting_name, model_name)
-            )
-
-    @property
-    def ACTIVE_CLASS(self):
-        return self._setting('ACTIVE_CLASS', 'active')
-
-    @property
-    def ADD_EDITOR_OVERRIDE_STYLES(self):
-        return self._setting('ADD_EDITOR_OVERRIDE_STYLES', True)
-
-    @property
-    def ACTIVE_ANCESTOR_CLASS(self):
-        return self._setting('ACTIVE_ANCESTOR_CLASS', 'ancestor')
-
-    @property
-    def MAINMENU_MENU_ICON(self):
-        return self._setting('MAINMENU_MENU_ICON', 'list-ol')
-
-    @property
-    def FLATMENU_MENU_ICON(self):
-        return self._setting('FLATMENU_MENU_ICON', 'list-ol')
-
-    @property
-    def USE_CONDENSEDINLINEPANEL(self):
-        return self._setting('USE_CONDENSEDINLINEPANEL', True)
-
-    @property
-    def SITE_SPECIFIC_TEMPLATE_DIRS(self):
-        return self._setting('SITE_SPECIFIC_TEMPLATE_DIRS', False)
-
-    @property
-    def SECTION_ROOT_DEPTH(self):
-        return self._setting('SECTION_ROOT_DEPTH', 3)
-
-    @property
-    def GUESS_TREE_POSITION_FROM_PATH(self):
-        return self._setting('GUESS_TREE_POSITION_FROM_PATH', True)
-
-    @property
-    def FLAT_MENUS_FALL_BACK_TO_DEFAULT_SITE_MENUS(self):
-        return self._setting(
-            'FLAT_MENUS_FALL_BACK_TO_DEFAULT_SITE_MENUS', False
-        )
-
-    @property
-    def DEFAULT_MAIN_MENU_TEMPLATE(self):
-        return self._setting(
-            'DEFAULT_MAIN_MENU_TEMPLATE', 'menus/main_menu.html'
-        )
-
-    @property
-    def DEFAULT_FLAT_MENU_TEMPLATE(self):
-        return self._setting(
-            'DEFAULT_FLAT_MENU_TEMPLATE', 'menus/flat_menu.html'
-        )
-
-    @property
-    def DEFAULT_SECTION_MENU_TEMPLATE(self):
-        return self._setting(
-            'DEFAULT_SECTION_MENU_TEMPLATE', 'menus/section_menu.html'
-        )
-
-    @property
-    def DEFAULT_CHILDREN_MENU_TEMPLATE(self):
-        return self._setting(
-            'DEFAULT_CHILDREN_MENU_TEMPLATE', 'menus/children_menu.html'
-        )
-
-    @property
-    def DEFAULT_SUB_MENU_TEMPLATE(self):
-        return self._setting(
-            'DEFAULT_SUB_MENU_TEMPLATE', 'menus/sub_menu.html'
-        )
-
-    @property
-    def DEFAULT_SECTION_MENU_MAX_LEVELS(self):
-        return self._setting('DEFAULT_SECTION_MENU_MAX_LEVELS', 2)
-
-    @property
-    def DEFAULT_CHILDREN_MENU_MAX_LEVELS(self):
-        return self._setting('DEFAULT_CHILDREN_MENU_MAX_LEVELS', 1)
-
-    @property
-    def DEFAULT_SECTION_MENU_USE_SPECIFIC(self):
-        return self._setting(
-            'DEFAULT_SECTION_MENU_USE_SPECIFIC', self.USE_SPECIFIC_AUTO
-        )
-
-    @property
-    def DEFAULT_CHILDREN_MENU_USE_SPECIFIC(self):
-        return self._setting(
-            'DEFAULT_CHILDREN_MENU_USE_SPECIFIC', self.USE_SPECIFIC_AUTO
-        )
-
-    @property
-    def FLAT_MENUS_HANDLE_CHOICES(self):
-        return self._setting('FLAT_MENUS_HANDLE_CHOICES')
-
-    @property
-    def PAGE_FIELD_FOR_MENU_ITEM_TEXT(self):
-        return self._setting("PAGE_FIELD_FOR_MENU_ITEM_TEXT", 'title')
-
-    @property
-    def MAIN_MENU_MODEL(self):
-        return self._setting('MAIN_MENU_MODEL', 'wagtailmenus.MainMenu')
-
-    @property
-    def MAIN_MENU_MODEL_CLASS(self):
-        return self.model_from_path_setting('MAIN_MENU_MODEL')
-
-    @property
-    def FLAT_MENU_MODEL(self):
-        return self._setting('FLAT_MENU_MODEL', 'wagtailmenus.FlatMenu')
-
-    @property
-    def FLAT_MENU_MODEL_CLASS(self):
-        return self.model_from_path_setting('FLAT_MENU_MODEL')
-
-    @property
-    def MAIN_MENU_ITEMS_RELATED_NAME(self):
-        return self._setting('MAIN_MENU_ITEMS_RELATED_NAME', 'menu_items')
-
-    @property
-    def FLAT_MENU_ITEMS_RELATED_NAME(self):
-        return self._setting('FLAT_MENU_ITEMS_RELATED_NAME', 'menu_items')
-
-    @property
-    def CHILDREN_MENU_CLASS_PATH(self):
-        return self._setting(
-            'CHILDREN_MENU_CLASS_PATH', 'wagtailmenus.models.ChildrenMenu'
-        )
-
-    @property
-    def CHILDREN_MENU_CLASS(self):
-        return self.class_from_path_setting('CHILDREN_MENU_CLASS_PATH')
-
-    @property
-    def SECTION_MENU_CLASS_PATH(self):
-        return self._setting(
-            'SECTION_MENU_CLASS_PATH', 'wagtailmenus.models.SectionMenu'
-        )
-
-    @property
-    def SECTION_MENU_CLASS(self):
-        return self.class_from_path_setting('SECTION_MENU_CLASS_PATH')
-
-    @property
-    def MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN(self):
-        return self._setting('MAIN_MENUS_EDITABLE_IN_WAGTAILADMIN', True)
-
-    @property
-    def FLAT_MENUS_EDITABLE_IN_WAGTAILADMIN(self):
-        return self._setting('FLAT_MENUS_EDITABLE_IN_WAGTAILADMIN', True)
-
-import sys  # noqa
-
-app_settings = AppSettings('WAGTAILMENUS_')
-app_settings.__name__ = __name__
-sys.modules[__name__] = app_settings
+sys.modules[__name__] = AppSettings('WAGTAILMENUS_', defaults)

--- a/wagtailmenus/constants.py
+++ b/wagtailmenus/constants.py
@@ -1,0 +1,18 @@
+from django.utils.translation import ugettext_lazy as _
+
+USE_SPECIFIC_OFF = 0
+USE_SPECIFIC_AUTO = 1
+USE_SPECIFIC_TOP_LEVEL = 2
+USE_SPECIFIC_ALWAYS = 3
+USE_SPECIFIC_CHOICES = (
+    (USE_SPECIFIC_OFF, _("Off (most efficient)")),
+    (USE_SPECIFIC_AUTO, _("Auto")),
+    (USE_SPECIFIC_TOP_LEVEL, _("Top level")),
+    (USE_SPECIFIC_ALWAYS, _("Always (least efficient)")),
+)
+MAX_LEVELS_CHOICES = (
+    (1, _('1: No sub-navigation (flat)')),
+    (2, _('2: Allow 1 level of sub-navigation')),
+    (3, _('3: Allow 2 levels of sub-navigation')),
+    (4, _('4: Allow 3 levels of sub-navigation')),
+)

--- a/wagtailmenus/context_processors.py
+++ b/wagtailmenus/context_processors.py
@@ -1,6 +1,6 @@
 from django.http import Http404
 from django.utils.functional import SimpleLazyObject
-from . import app_settings
+from . import app_settings, constants
 from .utils.misc import get_site_from_request
 
 
@@ -55,8 +55,8 @@ def wagtailmenus(request):
 
     return {
         'wagtailmenus_vals': SimpleLazyObject(_get_value_dict),
-        'USE_SPECIFIC_OFF': app_settings.USE_SPECIFIC_OFF,
-        'USE_SPECIFIC_AUTO': app_settings.USE_SPECIFIC_AUTO,
-        'USE_SPECIFIC_TOP_LEVEL': app_settings.USE_SPECIFIC_TOP_LEVEL,
-        'USE_SPECIFIC_ALWAYS': app_settings.USE_SPECIFIC_ALWAYS,
+        'USE_SPECIFIC_OFF': constants.USE_SPECIFIC_OFF,
+        'USE_SPECIFIC_AUTO': constants.USE_SPECIFIC_AUTO,
+        'USE_SPECIFIC_TOP_LEVEL': constants.USE_SPECIFIC_TOP_LEVEL,
+        'USE_SPECIFIC_ALWAYS': constants.USE_SPECIFIC_ALWAYS,
     }

--- a/wagtailmenus/forms.py
+++ b/wagtailmenus/forms.py
@@ -1,12 +1,11 @@
 from django import forms
 from django.utils.translation import ugettext_lazy as _
 from wagtail import VERSION as WAGTAIL_VERSION
+from wagtailmenus import app_settings
 if WAGTAIL_VERSION >= (2, 0):
     from wagtail.admin.forms import WagtailAdminModelForm, WagtailAdminPageForm
 else:
     from wagtail.wagtailadmin.forms import WagtailAdminModelForm, WagtailAdminPageForm
-
-from . import app_settings
 
 
 class FlatMenuAdminForm(WagtailAdminModelForm):

--- a/wagtailmenus/management/commands/autopopulate_main_menus.py
+++ b/wagtailmenus/management/commands/autopopulate_main_menus.py
@@ -2,12 +2,11 @@ import logging
 
 from django.core.management.base import BaseCommand
 from wagtail import VERSION as WAGTAIL_VERSION
+from wagtailmenus import app_settings
 if WAGTAIL_VERSION >= (2, 0):
     from wagtail.core.models import Site
 else:
     from wagtail.wagtailcore.models import Site
-
-from wagtailmenus import app_settings
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +30,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         for site in Site.objects.all():
-            menu = app_settings.MAIN_MENU_MODEL_CLASS.get_for_site(site)
+            menu_model = app_settings.get_model('MAIN_MENU_MODEL')
+            menu = menu_model.get_for_site(site)
             if not menu.get_menu_items_manager().exists():
                 menu.add_menu_items_for_pages(
                     site.root_page.get_descendants(

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -4,15 +4,14 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 from modelcluster.fields import ParentalKey
 from wagtail import VERSION as WAGTAIL_VERSION
+from wagtailmenus import app_settings
+from wagtailmenus.managers import MenuItemManager
 if WAGTAIL_VERSION >= (2, 0):
     from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
     from wagtail.core.models import Page, Orderable
 else:
     from wagtail.wagtailadmin.edit_handlers import FieldPanel, PageChooserPanel
     from wagtail.wagtailcore.models import Page, Orderable
-
-from .. import app_settings
-from ..managers import MenuItemManager
 
 
 #########################################################

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -6,14 +6,13 @@ from django.http import HttpResponse
 from django.shortcuts import redirect
 from django.utils.translation import ugettext_lazy as _
 from wagtail import VERSION as WAGTAIL_VERSION
+from wagtailmenus import app_settings
+from wagtailmenus.forms import LinkPageAdminForm
+from wagtailmenus.panels import menupage_settings_panels, linkpage_edit_handler
 if WAGTAIL_VERSION >= (2, 0):
     from wagtail.core.models import Page
 else:
     from wagtail.wagtailcore.models import Page
-
-from .. import app_settings
-from ..forms import LinkPageAdminForm
-from ..panels import menupage_settings_panels, linkpage_edit_handler
 
 
 class MenuPageMixin(models.Model):
@@ -91,8 +90,9 @@ class MenuPageMixin(models.Model):
         override this method if you're creating a multilingual site and you
         have different translations of 'repeated_item_text' that you wish to
         surface."""
+        source_field_name = app_settings.PAGE_FIELD_FOR_MENU_ITEM_TEXT
         return self.repeated_item_text or getattr(
-            self, app_settings.PAGE_FIELD_FOR_MENU_ITEM_TEXT, self.title
+            self, source_field_name, self.title
         )
 
     def get_repeated_menu_item(
@@ -191,11 +191,12 @@ class AbstractLinkPage(Page):
     def menu_text(self, request=None):
         """Return a string to use as link text when this page appears in
         menus."""
+        source_field_name = app_settings.PAGE_FIELD_FOR_MENU_ITEM_TEXT
         if(
-            app_settings.PAGE_FIELD_FOR_MENU_ITEM_TEXT != 'menu_text' and
-            hasattr(self, app_settings.PAGE_FIELD_FOR_MENU_ITEM_TEXT)
+            source_field_name != 'menu_text' and
+            hasattr(self, source_field_name)
         ):
-            return getattr(self, app_settings.PAGE_FIELD_FOR_MENU_ITEM_TEXT)
+            return getattr(self, source_field_name)
         return self.title
 
     def clean(self, *args, **kwargs):

--- a/wagtailmenus/panels.py
+++ b/wagtailmenus/panels.py
@@ -48,7 +48,9 @@ def FlatMenuItemsInlinePanel(**kwargs):  # noqa
     will be passed on as kwargs to the target class's __init__ method.
     """
     return _define_inlinepanel(
-        relation_name=app_settings.FLAT_MENU_ITEMS_RELATED_NAME, **kwargs)
+        relation_name=app_settings.FLAT_MENU_ITEMS_RELATED_NAME,
+        **kwargs
+    )
 
 
 def MainMenuItemsInlinePanel(**kwargs):  # noqa
@@ -61,7 +63,9 @@ def MainMenuItemsInlinePanel(**kwargs):  # noqa
     will be passed on as kwargs to the target class's __init__ method.
     """
     return _define_inlinepanel(
-        relation_name=app_settings.MAIN_MENU_ITEMS_RELATED_NAME, **kwargs)
+        relation_name=app_settings.MAIN_MENU_ITEMS_RELATED_NAME,
+        **kwargs
+    )
 
 
 main_menu_content_panels = (

--- a/wagtailmenus/templates/wagtailmenus/includes/header.html
+++ b/wagtailmenus/templates/wagtailmenus/includes/header.html
@@ -1,0 +1,13 @@
+<header class="merged tab-merged">
+    <div class="row nice-padding">
+        <div class="left">
+            <div class="col header-title">
+                <h1 class="icon icon-{{ icon }}">
+                {{ title }}{% if subtitle %} <span>{{ subtitle }}</span>{% endif %}</h1>
+            </div>
+        </div>
+        <div class="right">
+            {% block right_content %}{% endblock %}
+        </div>
+    </div>
+</header>

--- a/wagtailmenus/templates/wagtailmenus/includes/header_with_site_switcher.html
+++ b/wagtailmenus/templates/wagtailmenus/includes/header_with_site_switcher.html
@@ -1,0 +1,12 @@
+{% extends 'wagtailmenus/includes/header.html' %}
+
+{% block right_content %}
+    {% if site_switcher %}
+        <form method="get" id="settings-site-switch">
+            <label for="{{ site_switcher.site.id_for_label }}">
+                Site:
+            </label>
+            {{ site_switcher.site }}
+        </form>
+    {% endif %}  
+{% endblock %}

--- a/wagtailmenus/templates/wagtailmenus/mainmenu_edit.html
+++ b/wagtailmenus/templates/wagtailmenus/mainmenu_edit.html
@@ -1,56 +1,18 @@
 {% extends "modeladmin/create.html" %}
 {% load i18n %}
 
-{% block content %}
-    
-    <header class="nice-padding merged">
-        <div class="row">
-            <div class="left">
-                <div class="col">
-                    <h1 class="icon icon-{{ view.header_icon }}">
-                        {% trans view.page_title %}
-                        <span>{{ view.get_page_subtitle }}</span>
-                    </h1>
-                </div>
-            </div>
-            <div class="right">
-                {% if site_switcher %}
-                <form method="get" id="settings-site-switch">
-                    <label for="{{ site_switcher.site.id_for_label }}">
-                        Site:
-                    </label>
-                    {{ site_switcher.site }}
-                </form>
-                {% endif %}
-            </div>
-        </div>
-    </header>
-
-    <form action="?" method="POST">
-        {% csrf_token %}
-
-        {{ edit_handler.render_form_content }}
-        
-        <footer>
-            <ul>
-                <li class="actions">
-                    {% block form_actions %}
-                        <div class="dropdown dropup match-width">
-                            <input type="submit" value="{% trans 'Save' %}" class="button" />
-                        </div>
-                    {% endblock %}
-                </li>
-            </ul>
-        </footer>
-        
-    </form>
+{% block header %}
+    {% include "wagtailmenus/includes/header_with_site_switcher.html" with title=view.page_title subtitle=view.get_page_subtitle icon=view.header_icon %}
 {% endblock %}
+
+{% block form_action %}?{% endblock %}
 
 {% block extra_css %}
     {% include "wagtailadmin/pages/_editor_css.html" %}
     {{ edit_handler.form.media.css }}
     {{ view.media.css }}
 {% endblock %}
+
 {% block extra_js %}
     {% include "wagtailadmin/pages/_editor_js.html" %}
     {{ edit_handler.form.media.js }}

--- a/wagtailmenus/tests/test_commands.py
+++ b/wagtailmenus/tests/test_commands.py
@@ -1,13 +1,12 @@
 from django.test import TestCase
 from django.core.management import call_command
 from wagtail import VERSION as WAGTAIL_VERSION
+from wagtailmenus import app_settings
 if WAGTAIL_VERSION >= (2, 0):
     from wagtail.core.models import Site
 else:
     # < Wagtail 2.0
     from wagtail.wagtailcore.models import Site
-
-from wagtailmenus import app_settings
 
 
 class TestAutoPopulateMainMenus(TestCase):
@@ -16,7 +15,7 @@ class TestAutoPopulateMainMenus(TestCase):
     def setUp(self):
         super().setUp()
         # Delete any existing main menus and their items
-        self.model = app_settings.MAIN_MENU_MODEL_CLASS
+        self.model = app_settings.get_model('MAIN_MENU_MODEL')
         self.model.objects.all().delete()
 
     def test_without_home_links(self):

--- a/wagtailmenus/tests/test_custom_models.py
+++ b/wagtailmenus/tests/test_custom_models.py
@@ -395,7 +395,10 @@ class TestCustomMenuModels(TestCase):
     def test_children_menu_override(self):
         from wagtailmenus import app_settings
         from wagtailmenus.tests.models import CustomChildrenMenu
-        self.assertEqual(app_settings.CHILDREN_MENU_CLASS, CustomChildrenMenu)
+        self.assertEqual(
+            app_settings.get_class('CHILDREN_MENU_CLASS_PATH'),
+            CustomChildrenMenu
+        )
 
         # check that template specified with the classes 'template_name'
         # attribute is the one that gets picked up
@@ -406,7 +409,10 @@ class TestCustomMenuModels(TestCase):
     def test_section_menu_override(self):
         from wagtailmenus import app_settings
         from wagtailmenus.tests.models import CustomSectionMenu
-        self.assertEqual(app_settings.SECTION_MENU_CLASS, CustomSectionMenu)
+        self.assertEqual(
+            app_settings.get_class('SECTION_MENU_CLASS_PATH'),
+            CustomSectionMenu
+        )
 
         # check that template specified with the classes
         # 'sub_menu_template_name' attribute gets picked up
@@ -438,7 +444,7 @@ class TestInvalidCustomMenuModels(TestCase):
     @override_settings(WAGTAILMENUS_MAIN_MENU_MODEL='CustomMainMenu',)
     def test_main_menu_invalid_format(self):
         with self.assertRaisesMessage(ImproperlyConfigured, (
-                "WAGTAILMENUS_MAIN_MENU_MODEL must be of the form "
+                "WAGTAILMENUS_MAIN_MENU_MODEL must be in the format "
                 "'app_label.model_name'"
         )):
             get_main_menu_model()
@@ -454,7 +460,7 @@ class TestInvalidCustomMenuModels(TestCase):
     @override_settings(WAGTAILMENUS_FLAT_MENU_MODEL='CustomFlatMenu',)
     def test_flat_menu_invalid_format(self):
         with self.assertRaisesMessage(ImproperlyConfigured, (
-            "WAGTAILMENUS_FLAT_MENU_MODEL must be of the form "
+            "WAGTAILMENUS_FLAT_MENU_MODEL must be in the format "
             "'app_label.model_name'"
         )):
             get_flat_menu_model()
@@ -472,20 +478,20 @@ class TestInvalidCustomMenuModels(TestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, (
             "'CustomChildrenMenu' is not a valid import path. "
             "WAGTAILMENUS_CHILDREN_MENU_CLASS_PATH must be a full dotted "
-            "python import path e.g. 'project.app.file.Class'"
+            "python import path e.g. 'project.app.module.Class'"
         )):
             from wagtailmenus import app_settings
-            app_settings.CHILDREN_MENU_CLASS
+            app_settings.get_class('CHILDREN_MENU_CLASS_PATH')
 
-    @override_settings(WAGTAILMENUS_SECTION_MENU_CLASS_PATH='CustomSectionMenu', )
+    @override_settings(WAGTAILMENUS_SECTION_MENU_CLASS_PATH='CustomSectionMenu',)
     def test_section_menu_invalid_path(self):
         with self.assertRaisesMessage(ImproperlyConfigured, (
             "'CustomSectionMenu' is not a valid import path. "
             "WAGTAILMENUS_SECTION_MENU_CLASS_PATH must be a full dotted "
-            "python import path e.g. 'project.app.file.Class'"
+            "python import path e.g. 'project.app.module.Class'"
         )):
             from wagtailmenus import app_settings
-            app_settings.SECTION_MENU_CLASS
+            app_settings.get_class('SECTION_MENU_CLASS_PATH')
 
 
 class TestNoAbsoluteUrlsPage(TestCase):

--- a/wagtailmenus/tests/test_mainmenu_class.py
+++ b/wagtailmenus/tests/test_mainmenu_class.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from wagtailmenus import app_settings
+from wagtailmenus import constants
 from wagtailmenus.models import MainMenu
 from wagtailmenus.tests import base, utils
 
@@ -78,7 +78,7 @@ class TestTopLevelItems(MainMenuTestCase):
 
     def test_method_initiates_two_queries_when_vanilla_page_data_is_required(self, menu_obj=None):
         menu = menu_obj or MainMenu.objects.get(pk=1)
-        menu.use_specific = app_settings.USE_SPECIFIC_AUTO
+        menu.use_specific = constants.USE_SPECIFIC_AUTO
         with self.assertNumQueries(2):
             menu.get_top_level_items()
 

--- a/wagtailmenus/tests/test_menu_items.py
+++ b/wagtailmenus/tests/test_menu_items.py
@@ -1,17 +1,16 @@
 from django.core.exceptions import ValidationError
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.test.client import RequestFactory
 
 from wagtail import VERSION as WAGTAIL_VERSION
-if WAGTAIL_VERSION >= (2, 0):
-    from wagtail.core.models import Page
-else:
-    from wagtail.wagtailcore.models import Page
-
 from wagtailmenus.models import (
     AbstractMenuItem, MainMenu, MainMenuItem, FlatMenu, FlatMenuItem
 )
 from wagtailmenus import app_settings
+if WAGTAIL_VERSION >= (2, 0):
+    from wagtail.core.models import Page
+else:
+    from wagtail.wagtailcore.models import Page
 
 
 class MenuItemModelTestMixin:

--- a/wagtailmenus/tests/utils.py
+++ b/wagtailmenus/tests/utils.py
@@ -3,7 +3,7 @@ from django.test.client import RequestFactory
 from wagtail import VERSION as WAGTAIL_VERSION
 
 from wagtailmenus.models.menus import ContextualVals, OptionVals
-from wagtailmenus import app_settings
+from wagtailmenus import constants
 
 SUB_MENU_TEMPLATE_LIST = (
     'menus/sub_menu_level_2.html',
@@ -30,7 +30,7 @@ def get_site_model():
 
 def make_optionvals_instance(
     max_levels=2,
-    use_specific=app_settings.USE_SPECIFIC_AUTO,
+    use_specific=constants.USE_SPECIFIC_AUTO,
     apply_active_classes=True,
     allow_repeating_parents=True,
     use_absolute_page_urls=False,

--- a/wagtailmenus/utils/conf.py
+++ b/wagtailmenus/utils/conf.py
@@ -1,0 +1,56 @@
+from importlib import import_module
+from django.core.exceptions import ImproperlyConfigured
+
+
+class AppSettings:
+
+    def __init__(self, prefix, defaults):
+        self.prefix = prefix
+        self.defaults = defaults
+
+    def __getattr__(self, name):
+        try:
+            return self.get(name)
+        except KeyError:
+            return super().__getattr__(name)
+
+    def get(self, setting_name):
+        """Returns an app setting value in it's native format, e.g.
+        string, integer, boolean. If the setting cannot be found in django
+        project settings, the relevant default value from defaults is returned.
+        """
+        from django.conf import settings  # delay import until needed
+        default = self.defaults[setting_name]
+        return getattr(settings, self.prefix + setting_name, default)
+
+    def get_class(self, setting_name):
+        """Returns a python class, method, module or other object referenced by
+        an app setting who's value should be a valid import path string."""
+        value = self.get(setting_name)
+        try:
+            module_path, class_name = value.rsplit(".", 1)
+            return getattr(import_module(module_path), class_name)
+        except(ImportError, ValueError):
+            raise ImproperlyConfigured(
+                "'%s' is not a valid import path. %s%s must be a full "
+                "dotted python import path e.g. 'project.app.module.Class'" %
+                (value, self.prefix, setting_name)
+            )
+
+    def get_model(self, setting_name):
+        """Returns a Django model referenced by an app setting who's value
+        should be a 'model' string in the format 'app_label.model_name'."""
+        from django.apps import apps  # delay import until needed
+        value = self.get(setting_name)
+        try:
+            return apps.get_model(value)
+        except ValueError:
+            raise ImproperlyConfigured(
+                "%s%s must be in the format 'app_label.model_name'" %
+                (self.prefix, setting_name)
+            )
+        except LookupError:
+            raise ImproperlyConfigured(
+                "%s%s refers to model '%s' that has not been installed" %
+                (self.prefix, setting_name, value)
+            )

--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -7,6 +7,9 @@ from django.shortcuts import get_object_or_404, redirect
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 from wagtail import VERSION as WAGTAIL_VERSION
+from wagtail.contrib.modeladmin.views import (
+    WMABaseView, CreateView, EditView, ModelFormView)
+from wagtailmenus import app_settings
 if WAGTAIL_VERSION >= (2, 0):
     from wagtail.admin import messages
     from wagtail.admin.edit_handlers import ObjectList, TabbedInterface
@@ -15,10 +18,6 @@ else:
     from wagtail.wagtailadmin import messages
     from wagtail.wagtailadmin.edit_handlers import ObjectList, TabbedInterface
     from wagtail.wagtailcore.models import Site
-from wagtail.contrib.modeladmin.views import (
-    WMABaseView, CreateView, EditView, ModelFormView)
-
-from . import app_settings
 
 
 class SiteSwitchForm(forms.Form):

--- a/wagtailmenus/wagtail_hooks.py
+++ b/wagtailmenus/wagtail_hooks.py
@@ -3,20 +3,21 @@ from django.contrib.admin.utils import quote
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from wagtail import VERSION as WAGTAIL_VERSION
+from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail.contrib.modeladmin.helpers import ButtonHelper
+from wagtailmenus import app_settings
+from wagtailmenus.views import (
+    MainMenuIndexView, MainMenuEditView, FlatMenuCreateView,
+    FlatMenuEditView, FlatMenuCopyView
+)
 if WAGTAIL_VERSION >= (2, 0):
     from wagtail.core import hooks
 else:
     from wagtail.wagtailcore import hooks
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
-from wagtail.contrib.modeladmin.helpers import ButtonHelper
-
-from . import app_settings, get_main_menu_model, get_flat_menu_model
-from .views import (MainMenuIndexView, MainMenuEditView, FlatMenuCreateView,
-                    FlatMenuEditView, FlatMenuCopyView)
 
 
 class MainMenuAdmin(ModelAdmin):
-    model = get_main_menu_model()
+    model = app_settings.get_model('MAIN_MENU_MODEL')
     menu_label = _('Main menu')
     menu_icon = app_settings.MAINMENU_MENU_ICON
     index_view_class = MainMenuIndexView
@@ -71,7 +72,7 @@ class FlatMenuButtonHelper(ButtonHelper):
 
 
 class FlatMenuAdmin(ModelAdmin):
-    model = get_flat_menu_model()
+    model = app_settings.get_model('FLAT_MENU_MODEL')
     menu_label = _('Flat menus')
     menu_icon = app_settings.FLATMENU_MENU_ICON
     button_helper_class = FlatMenuButtonHelper


### PR DESCRIPTION
- Move constants to their own module, rather than throwing them in with other settings
- Overrides `__getattr__` on AppSettings class to provide 'attribute like' references to settings without having to define a new property method for each one
- Default setting values are defined together in a single, simple dictionary
- Adds 'get_class' and 'get_model' methods to AppSettings class to provide a more sensible way to fetch python classes or django models referenced by settings