### PR TITLE
Housekeeping for 2.11a

### DIFF
--- a/docs/source/releases/2.11.0.rst
+++ b/docs/source/releases/2.11.0.rst
@@ -1,0 +1,37 @@
+=======================================
+Wagtailmenus 2.11 (alpha) release notes
+=======================================
+
+.. NOTE ::
+    
+    Wagtailmenus 2.11 is in the alpha stage of development. Any changes
+    detailed below are subject to change before the final 2.11 release.
+
+
+.. contents::
+    :local:
+    :depth: 1
+
+
+What's new?
+===========
+
+TBA
+
+
+Minor changes & bug fixes 
+=========================
+
+TBA
+
+
+Deprecations
+============
+
+TBA
+
+
+Upgrade considerations
+======================
+
+TBA

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -5,6 +5,7 @@ Release notes
 .. toctree::
     :maxdepth: 1
 
+    2.11.0
     2.10.0
     2.9.0
     2.8.0

--- a/runtests.py
+++ b/runtests.py
@@ -24,25 +24,25 @@ def parse_args(args=None):
 
 
 def runtests():
-    args, rest = parse_args()
+    parsed_args, unparsed_args = parse_args()
 
     only_wagtailmenus = r'^wagtailmenus(\.|$)'
-    if args.deprecation == 'all':
+    if parsed_args.deprecation == 'all':
         # Show all deprecation warnings from all packages
         warnings.simplefilter('default', category=DeprecationWarning)
         warnings.simplefilter('default', category=PendingDeprecationWarning)
-    elif args.deprecation == 'pending':
+    elif parsed_args.deprecation == 'pending':
         # Show all deprecation warnings
         warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtailmenus)
         warnings.filterwarnings('default', category=PendingDeprecationWarning, module=only_wagtailmenus)
-    elif args.deprecation == 'imminent':
+    elif parsed_args.deprecation == 'imminent':
         # Show only imminent deprecation warnings
         warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtailmenus)
-    elif args.deprecation == 'none':
+    elif parsed_args.deprecation == 'none':
         # Deprecation warnings are ignored
         pass
 
-    argv = [sys.argv[0], 'test'] + rest
+    argv = [sys.argv[0], 'test'] + unparsed_args
     return execute_from_command_line(argv)
 
 if __name__ == '__main__':

--- a/runtests.py
+++ b/runtests.py
@@ -20,29 +20,30 @@ def make_parser():
 
 
 def parse_args(args=None):
-    return make_parser().parse_args(args)
+    return make_parser().parse_known_args(args)
 
 
 def runtests():
-    args = parse_args()
+    args, rest = parse_args()
 
+    only_wagtailmenus = r'^wagtailmenus(\.|$)'
     if args.deprecation == 'all':
         # Show all deprecation warnings from all packages
         warnings.simplefilter('default', category=DeprecationWarning)
         warnings.simplefilter('default', category=PendingDeprecationWarning)
     elif args.deprecation == 'pending':
         # Show all deprecation warnings
-        warnings.filterwarnings('default', category=DeprecationWarning)
-        warnings.filterwarnings('default', category=PendingDeprecationWarning)
+        warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtailmenus)
+        warnings.filterwarnings('default', category=PendingDeprecationWarning, module=only_wagtailmenus)
     elif args.deprecation == 'imminent':
         # Show only imminent deprecation warnings
-        warnings.filterwarnings('default', category=DeprecationWarning)
+        warnings.filterwarnings('default', category=DeprecationWarning, module=only_wagtailmenus)
     elif args.deprecation == 'none':
-        # Deprecation warnings are ignored by default
+        # Deprecation warnings are ignored
         pass
 
-    argv = [sys.argv[0], 'test']
+    argv = [sys.argv[0], 'test'] + rest
     return execute_from_command_line(argv)
-    
+
 if __name__ == '__main__':
     sys.exit(runtests())

--- a/wagtailmenus/__init__.py
+++ b/wagtailmenus/__init__.py
@@ -2,7 +2,7 @@ from wagtailmenus.utils.version import get_version, get_stable_branch_name
 
 # major.minor.patch.release.number
 # release must be one of alpha, beta, rc, or final
-VERSION = (2, 10, 0, 'final', 0)
+VERSION = (2, 11, 0, 'alpha', 0)
 __version__ = get_version(VERSION)
 stable_branch_name = get_stable_branch_name(VERSION)
 

--- a/wagtailmenus/utils/deprecation.py
+++ b/wagtailmenus/utils/deprecation.py
@@ -1,13 +1,13 @@
-class RemovedInWagtailMenus211Warning(DeprecationWarning):
+class RemovedInWagtailMenus212Warning(DeprecationWarning):
     pass
 
 
-removed_in_next_version_warning = RemovedInWagtailMenus211Warning
-
-
-class RemovedInWagtailMenus212Warning(PendingDeprecationWarning):
-    pass
+removed_in_next_version_warning = RemovedInWagtailMenus212Warning
 
 
 class RemovedInWagtailMenus213Warning(PendingDeprecationWarning):
+    pass
+
+
+class RemovedInWagtailMenus214Warning(PendingDeprecationWarning):
     pass


### PR DESCRIPTION
- Bump version to, and add release notes for 2.11a
- Cycle deprecation warnings and remove anything that needs removing (nothing this time)
- Update runtests.py command while here, to make test options and output more useful