### PR TITLE
Rename deprecation warning classes

### DIFF
--- a/wagtailmenus/utils/deprecation.py
+++ b/wagtailmenus/utils/deprecation.py
@@ -5,9 +5,9 @@ class RemovedInWagtailMenus213Warning(DeprecationWarning):
 removed_in_next_version_warning = RemovedInWagtailMenus213Warning
 
 
-class RemovedInWagtailMenus214Warning(PendingDeprecationWarning):
+class RemovedInWagtailMenus3Warning(PendingDeprecationWarning):
     pass
 
 
-class RemovedInWagtailMenus215Warning(PendingDeprecationWarning):
+class RemovedInWagtailMenus31Warning(PendingDeprecationWarning):
     pass


### PR DESCRIPTION
Rename deprecation warning classes to indicate that the version after v2.13 will be v3.0