### PR TITLE
Menu class code readability improvements

### DIFF
--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -96,8 +96,8 @@ class Menu:
         ``RequestContext`` object) and supplied option values, then calls that
         object's prepare_to_render() method before returning it.
         """
-        ctx_vals = cls._create_contextualvals_object_from_context(context)
-        opt_vals = cls._create_optionvals_object_from_values(**option_vals)
+        ctx_vals = cls.get_contextual_vals_from_context(context)
+        opt_vals = cls.get_option_vals_from_options(**option_vals)
         instance = cls.get_instance_for_rendering(ctx_vals, opt_vals)
         if not instance:
             return

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -675,14 +675,13 @@ class SectionMenu(DefinesSubMenuTemplatesMixin, MenuFromPage):
 
     @classmethod
     def render_from_tag(
-        cls, context, root_page, max_levels=None, use_specific=None,
+        cls, context, max_levels=None, use_specific=None,
         apply_active_classes=True, allow_repeating_parents=True,
         use_absolute_page_urls=False, template_name='',
         sub_menu_template_name='', sub_menu_template_names=None, **kwargs
     ):
         return super().render_from_tag(
             context,
-            root_page=root_page,
             max_levels=max_levels,
             use_specific=use_specific,
             apply_active_classes=apply_active_classes,

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -74,35 +74,20 @@ class Menu:
             * get_context_data()
             * render_to_template()
         """
-        instance = cls._get_render_prepared_instance(
-            context,
+        ctx_vals = cls.get_contextual_vals_from_context(context)
+        opt_vals = cls.get_option_vals_from_options(
             max_levels=max_levels,
             use_specific=use_specific,
             apply_active_classes=apply_active_classes,
             allow_repeating_parents=allow_repeating_parents,
             use_absolute_page_urls=use_absolute_page_urls,
             template_name=template_name,
-            **kwargs
-        )
-        if not instance:
-            return ''
-        return instance.render_to_template()
-
-    @classmethod
-    def _get_render_prepared_instance(cls, context, **option_vals):
-        """
-        Calls the class's get_instance_for_rendering() method to fetch or
-        create a menu object appropriate for ``context`` (typically a
-        ``RequestContext`` object) and supplied option values, then calls that
-        object's prepare_to_render() method before returning it.
-        """
-        ctx_vals = cls.get_contextual_vals_from_context(context)
-        opt_vals = cls.get_option_vals_from_options(**option_vals)
+            **kwargs)
         instance = cls.get_instance_for_rendering(ctx_vals, opt_vals)
         if not instance:
-            return
+            return ''
         instance.prepare_to_render(context['request'], ctx_vals, opt_vals)
-        return instance
+        return instance.render_to_template()
 
     @classmethod
     def get_contextual_vals_from_context(cls, context):

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -675,13 +675,14 @@ class SectionMenu(DefinesSubMenuTemplatesMixin, MenuFromPage):
 
     @classmethod
     def render_from_tag(
-        cls, context, max_levels=None, use_specific=None,
+        cls, context, show_section_root=True, max_levels=None, use_specific=None,
         apply_active_classes=True, allow_repeating_parents=True,
         use_absolute_page_urls=False, template_name='',
         sub_menu_template_name='', sub_menu_template_names=None, **kwargs
     ):
         return super().render_from_tag(
             context,
+            show_section_root=show_section_root,
             max_levels=max_levels,
             use_specific=use_specific,
             apply_active_classes=apply_active_classes,
@@ -1202,13 +1203,16 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
 
     @classmethod
     def render_from_tag(
-        cls, context, handle, max_levels=None, use_specific=None,
-        apply_active_classes=True, allow_repeating_parents=True,
-        use_absolute_page_urls=False, template_name='',
-        sub_menu_template_name='', sub_menu_template_names=None, **kwargs
+        cls, context, handle, fall_back_to_default_site_menus=True,
+        max_levels=None, use_specific=None, apply_active_classes=True,
+        allow_repeating_parents=True, use_absolute_page_urls=False,
+        template_name='', sub_menu_template_name='',
+        sub_menu_template_names=None, **kwargs
     ):
         return super().render_from_tag(
             context,
+            handle=handle,
+            fall_back_to_default_site_menus=fall_back_to_default_site_menus,
             max_levels=max_levels,
             use_specific=use_specific,
             apply_active_classes=apply_active_classes,

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -53,7 +53,11 @@ class Menu:
     sub_menu_class = None
 
     @classmethod
-    def render_from_tag(cls, context, **options):
+    def render_from_tag(
+        cls, context, max_levels=None, use_specific=None,
+        apply_active_classes=True, allow_repeating_parents=True,
+        use_absolute_page_urls=False, template_name='', **kwargs
+    ):
         """
         A template tag should call this method to render a menu.
         The ``Context`` instance and option values provided are used to get or
@@ -70,14 +74,35 @@ class Menu:
             * get_context_data()
             * render_to_template()
         """
-        ctx_vals = cls.get_contextual_vals_from_context(context)
-        opt_vals = cls.get_option_vals_from_options(**options)
-        instance = cls.get_instance_for_rendering(ctx_vals, opt_vals)
+        instance = cls._get_render_prepared_instance(
+            context,
+            max_levels=max_levels,
+            use_specific=use_specific,
+            apply_active_classes=apply_active_classes,
+            allow_repeating_parents=allow_repeating_parents,
+            use_absolute_page_urls=use_absolute_page_urls,
+            template_name=template_name,
+            **kwargs
+        )
         if not instance:
             return ''
-
-        instance.prepare_to_render(context['request'], ctx_vals, opt_vals)
         return instance.render_to_template()
+
+    @classmethod
+    def _get_render_prepared_instance(cls, context, **option_vals):
+        """
+        Calls the class's get_instance_for_rendering() method to fetch or
+        create a menu object appropriate for ``context`` (typically a
+        ``RequestContext`` object) and supplied option values, then calls that
+        object's prepare_to_render() method before returning it.
+        """
+        ctx_vals = cls._create_contextualvals_object_from_context(context)
+        opt_vals = cls._create_optionvals_object_from_values(**option_vals)
+        instance = cls.get_instance_for_rendering(ctx_vals, opt_vals)
+        if not instance:
+            return
+        instance.prepare_to_render(context['request'], ctx_vals, opt_vals)
+        return instance
 
     @classmethod
     def get_contextual_vals_from_context(cls, context):
@@ -664,6 +689,27 @@ class SectionMenu(DefinesSubMenuTemplatesMixin, MenuFromPage):
     related_templatetag_name = 'section_menu'
 
     @classmethod
+    def render_from_tag(
+        cls, context, root_page, max_levels=None, use_specific=None,
+        apply_active_classes=True, allow_repeating_parents=True,
+        use_absolute_page_urls=False, template_name='',
+        sub_menu_template_name='', sub_menu_template_names=None, **kwargs
+    ):
+        return super().render_from_tag(
+            context,
+            root_page=root_page,
+            max_levels=max_levels,
+            use_specific=use_specific,
+            apply_active_classes=apply_active_classes,
+            allow_repeating_parents=allow_repeating_parents,
+            use_absolute_page_urls=use_absolute_page_urls,
+            template_name=template_name,
+            sub_menu_template_name=sub_menu_template_name,
+            sub_menu_template_names=sub_menu_template_names,
+            **kwargs
+        )
+
+    @classmethod
     def get_instance_for_rendering(cls, contextual_vals, option_vals):
         if not contextual_vals.current_section_root_page:
             return
@@ -756,6 +802,27 @@ class ChildrenMenu(DefinesSubMenuTemplatesMixin, MenuFromPage):
     related_templatetag_name = 'children_menu'
 
     @classmethod
+    def render_from_tag(
+        cls, context, parent_page, max_levels=None, use_specific=None,
+        apply_active_classes=True, allow_repeating_parents=True,
+        use_absolute_page_urls=False, template_name='',
+        sub_menu_template_name='', sub_menu_template_names=None, **kwargs
+    ):
+        return super().render_from_tag(
+            context,
+            parent_page=parent_page,
+            max_levels=max_levels,
+            use_specific=use_specific,
+            apply_active_classes=apply_active_classes,
+            allow_repeating_parents=allow_repeating_parents,
+            use_absolute_page_urls=use_absolute_page_urls,
+            template_name=template_name,
+            sub_menu_template_name=sub_menu_template_name,
+            sub_menu_template_names=sub_menu_template_names,
+            **kwargs
+        )
+
+    @classmethod
     def get_instance_for_rendering(cls, contextual_vals, option_vals):
         parent_page = option_vals.parent_page or contextual_vals.current_page
         if not parent_page:
@@ -789,6 +856,24 @@ class SubMenu(MenuFromPage):
     menu_short_name = 'sub'  # used to find templates
     menu_instance_context_name = 'sub_menu'
     related_templatetag_name = 'sub_menu'
+
+    @classmethod
+    def render_from_tag(
+        cls, context, parent_page, max_levels=None, use_specific=None,
+        apply_active_classes=True, allow_repeating_parents=True,
+        use_absolute_page_urls=False, template_name='', **kwargs
+    ):
+        return super().render_from_tag(
+            context,
+            parent_page=parent_page,
+            max_levels=max_levels,
+            use_specific=use_specific,
+            apply_active_classes=apply_active_classes,
+            allow_repeating_parents=allow_repeating_parents,
+            use_absolute_page_urls=use_absolute_page_urls,
+            template_name=template_name,
+            **kwargs
+        )
 
     @classmethod
     def get_instance_for_rendering(cls, contextual_vals, option_vals):
@@ -1026,6 +1111,26 @@ class AbstractMainMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
         verbose_name_plural = _("main menu")
 
     @classmethod
+    def render_from_tag(
+        cls, context, max_levels=None, use_specific=None,
+        apply_active_classes=True, allow_repeating_parents=True,
+        use_absolute_page_urls=False, template_name='',
+        sub_menu_template_name='', sub_menu_template_names=None, **kwargs
+    ):
+        return super().render_from_tag(
+            context,
+            max_levels=max_levels,
+            use_specific=use_specific,
+            apply_active_classes=apply_active_classes,
+            allow_repeating_parents=allow_repeating_parents,
+            use_absolute_page_urls=use_absolute_page_urls,
+            template_name=template_name,
+            sub_menu_template_name=sub_menu_template_name,
+            sub_menu_template_names=sub_menu_template_names,
+            **kwargs
+        )
+
+    @classmethod
     def get_instance_for_rendering(cls, contextual_vals, option_vals):
         try:
             return cls.get_for_site(contextual_vals.current_site)
@@ -1110,6 +1215,26 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
         unique_together = ("site", "handle")
         verbose_name = _("flat menu")
         verbose_name_plural = _("flat menus")
+
+    @classmethod
+    def render_from_tag(
+        cls, context, handle, max_levels=None, use_specific=None,
+        apply_active_classes=True, allow_repeating_parents=True,
+        use_absolute_page_urls=False, template_name='',
+        sub_menu_template_name='', sub_menu_template_names=None, **kwargs
+    ):
+        return super().render_from_tag(
+            context,
+            max_levels=max_levels,
+            use_specific=use_specific,
+            apply_active_classes=apply_active_classes,
+            allow_repeating_parents=allow_repeating_parents,
+            use_absolute_page_urls=use_absolute_page_urls,
+            template_name=template_name,
+            sub_menu_template_name=sub_menu_template_name,
+            sub_menu_template_names=sub_menu_template_names,
+            **kwargs
+        )
 
     @classmethod
     def get_instance_for_rendering(cls, contextual_vals, option_vals):


### PR DESCRIPTION
- Alter the signature of Menu.render_from_tag() to give an indication of common expected/supported arguments.
- Override render_from_tag() for each menu class so that the signature indicates how the supported arguments vary for each menu type.