### PR TITLE
Menu method renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ Changelog
 2.12.0 (XX.XX.XXXX)
 -------------------
 
-* TBA
+* Changed the signature of ``Menu.render_from_tag()`` to better indicate common expected/supported arguments for menus.
+* Added a custom ``render_from_tag()`` method for each individual menu class, with a signature that highlights all relevant options, including those specific to that menu type.
+* Renamed ``Menu.get_contextual_vals_from_context()`` to ``Menu._create_contextualvals_obj_from_context()`` to give a better
+indication of what the method does.
+* Renamed ``Menu.get_option_vals_from_options`` to ``Menu._create_optionvals_obj_from_values()`` to give a better indication of what the method does.
+* Added the ``Menu.get_from_collected_values()`` method, which replaces ``Menu.get_instance_for_rendering()`` for menu classes that also inherit from ``django.db.models.Model``.
+* Added the ``Menu.create_from_collected_values()`` method, which replaces ``Menu.get_instance_for_rendering()`` for menu classes that **do not** inherit from ``django.db.models.Model``.
 
 
 2.11.1 (10.09.2018)

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -80,7 +80,7 @@ class Menu:
         """
 
         # The following two conditionals are to be removed in v3
-        if cls.get_contextual_vals_from_context is not Menu.get_contextual_vals_from_context:
+        if cls.get_contextual_vals_from_context.__func__ is not Menu.get_contextual_vals_from_context.__func__:
             warnings.warn(
                 "From v2.12, the get_contextual_vals_from_context() class "
                 "method is deprecated, and will be removed in v3. Use "
@@ -90,7 +90,7 @@ class Menu:
             ctx_vals = cls.get_contextual_vals_from_context(context)
         else:
             ctx_vals = cls._create_contextualvals_obj_from_context(context)
-        if cls.get_option_vals_from_options is not Menu.get_option_vals_from_options:
+        if cls.get_option_vals_from_options.__func__ is not Menu.get_option_vals_from_options.__func__:
             warnings.warn(
                 "From v2.12, the get_option_vals_from_options() class "
                 "method is deprecated, and will be removed in v3. Use "

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -167,14 +167,14 @@ class Menu:
         )
 
     @classmethod
-    def get_option_vals_from_options(cls, context):
+    def get_option_vals_from_options(cls, **kwargs):
         warnings.warn(
             'The get_option_vals_from_options() class method is '
             'deprecated in v2.12 and will be removed in v3. Use '
             '_create_optionvals_obj_from_values() instead.',
             category=RemovedInWagtailMenus3Warning
         )
-        return cls._create_optionvals_obj_from_values(context)
+        return cls._create_optionvals_obj_from_values(**kwargs)
 
     @classmethod
     def get_or_create_from_values(cls, contextual_vals, option_vals):

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -111,7 +111,7 @@ class Menu:
             **kwargs)
         # TODO: The following conditional is to be removed in v3
         is_model_class = issubclass(cls, models.Model)
-        if hasattr(cls, 'get_instance_for_rendering'):
+        if cls.get_instance_for_rendering.__func__ is not Menu.get_instance_for_rendering.__func__:
             warnings.warn(
                 "From v2.12, the get_instance_for_rendering() class "
                 "method is deprecated, and will be removed in v3. For "
@@ -226,6 +226,18 @@ class Menu:
             "Subclasses of 'Menu' and 'django.db.models.Model' must define "
             "their own 'get_from_collected_values' method."
         )
+
+    @classmethod
+    def get_instance_for_rendering(cls, contextual_vals, option_vals):
+        warnings.warn(
+            'The get_instance_for_rendering() class method is deprecated in '
+            'v2.12 and will be removed in v3. Use create_relevant_object_from_values() '
+            'instead.', category=RemovedInWagtailMenus3Warning
+        )
+        if issubclass(cls, models.Model):
+            return cls.get_from_collected_values(contextual_vals, option_vals)
+
+        return cls.create_from_collected_values(contextual_vals, option_vals)
 
     def get_sub_menu_class(self):
         """

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -76,8 +76,18 @@ class Menu:
             * get_context_data()
             * render_to_template()
         """
-        ctx_vals = cls.get_contextual_vals_from_context(context)
-        opt_vals = cls.get_option_vals_from_options(
+
+        # The following two conditionals are to be removed in v3
+        if cls.get_contextual_vals_from_context is not Menu.get_contextual_vals_from_context:
+            ctx_vals = cls.get_contextual_vals_from_context(context)
+        else:
+            ctx_vals = cls._create_contextualvals_obj_from_context(context)
+        if cls.get_option_vals_from_options is not Menu.get_option_vals_from_options:
+            optvals_create_method = cls.get_option_vals_from_options
+        else:
+            optvals_create_method = cls._create_optionvals_obj_from_values
+
+        opt_vals = optvals_create_method(
             max_levels=max_levels,
             use_specific=use_specific,
             apply_active_classes=apply_active_classes,
@@ -96,7 +106,7 @@ class Menu:
         return instance.render_to_template()
 
     @classmethod
-    def get_contextual_vals_from_context(cls, context):
+    def _create_contextualvals_obj_from_context(cls, context):
         """
         Gathers all of the 'contextual' data needed to render a menu instance
         and returns it in a structure that can be conveniently referenced
@@ -117,7 +127,17 @@ class Menu:
         )
 
     @classmethod
-    def get_option_vals_from_options(cls, **options):
+    def get_contextual_vals_from_context(cls, context):
+        warnings.warn(
+            'The get_contextual_vals_from_context() class method is '
+            'deprecated in v2.12 and will be removed in v3. Use '
+            '_create_contextualvals_obj_from_context() instead.',
+            category=RemovedInWagtailMenus3Warning
+        )
+        return cls._create_contextualvals_obj_from_context(context)
+
+    @classmethod
+    def _create_optionvals_obj_from_values(cls, **kwargs):
         """
         Takes all of the options passed to the class's ``render_from_tag()``
         method and returns them in a structure that can be conveniently
@@ -133,18 +153,28 @@ class Menu:
             option_vals.extra['fall_back_to_default_site_menus']
         """
         return OptionVals(
-            options.pop('max_levels'),
-            options.pop('use_specific'),
-            options.pop('apply_active_classes'),
-            options.pop('allow_repeating_parents'),
-            options.pop('use_absolute_page_urls'),
-            options.pop('parent_page', None),
-            options.pop('handle', None),  # for AbstractFlatMenu
-            options.pop('template_name', ''),
-            options.pop('sub_menu_template_name', ''),
-            options.pop('sub_menu_template_names', None),
-            options  # anything left over will be stored as 'extra'
+            kwargs.pop('max_levels'),
+            kwargs.pop('use_specific'),
+            kwargs.pop('apply_active_classes'),
+            kwargs.pop('allow_repeating_parents'),
+            kwargs.pop('use_absolute_page_urls'),
+            kwargs.pop('parent_page', None),
+            kwargs.pop('handle', None),  # for AbstractFlatMenu
+            kwargs.pop('template_name', ''),
+            kwargs.pop('sub_menu_template_name', ''),
+            kwargs.pop('sub_menu_template_names', None),
+            kwargs  # anything left over will be stored as 'extra'
         )
+
+    @classmethod
+    def get_option_vals_from_options(cls, context):
+        warnings.warn(
+            'The get_option_vals_from_options() class method is '
+            'deprecated in v2.12 and will be removed in v3. Use '
+            '_create_optionvals_obj_from_values() instead.',
+            category=RemovedInWagtailMenus3Warning
+        )
+        return cls._create_optionvals_obj_from_values(context)
 
     @classmethod
     def get_or_create_from_values(cls, contextual_vals, option_vals):

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -81,10 +81,22 @@ class Menu:
 
         # The following two conditionals are to be removed in v3
         if cls.get_contextual_vals_from_context is not Menu.get_contextual_vals_from_context:
+            warnings.warn(
+                "From v2.12, the get_contextual_vals_from_context() class "
+                "method is deprecated, and will be removed in v3. Use "
+                "get_contextual_vals_from_context() instead.",
+                category=RemovedInWagtailMenus3Warning
+            )
             ctx_vals = cls.get_contextual_vals_from_context(context)
         else:
             ctx_vals = cls._create_contextualvals_obj_from_context(context)
         if cls.get_option_vals_from_options is not Menu.get_option_vals_from_options:
+            warnings.warn(
+                "From v2.12, the get_option_vals_from_options() class "
+                "method is deprecated, and will be removed in v3. Use "
+                "_create_optionvals_obj_from_values() instead.",
+                category=RemovedInWagtailMenus3Warning
+            )
             optvals_create_method = cls.get_option_vals_from_options
         else:
             optvals_create_method = cls._create_optionvals_obj_from_values
@@ -98,13 +110,23 @@ class Menu:
             template_name=template_name,
             **kwargs)
         # TODO: The following conditional is to be removed in v3
-        if cls.get_instance_for_rendering is not Menu.get_instance_for_rendering:
+        is_model_class = issubclass(cls, models.Model)
+        if hasattr(cls, 'get_instance_for_rendering'):
+            warnings.warn(
+                "From v2.12, the get_instance_for_rendering() class "
+                "method is deprecated, and will be removed in v3. For "
+                "'{}', you should override the {}() method instead.".format(
+                    cls.__name__,
+                    'get_from_collected_values' if is_model_class
+                    else 'create_from_collected_values'
+                ),
+                category=RemovedInWagtailMenus3Warning
+            )
             instance = cls.get_instance_for_rendering(ctx_vals, opt_vals)
+        elif is_model_class:
+            instance = cls.get_from_collected_values(ctx_vals, opt_vals)
         else:
-            if issubclass(cls, models.Model):
-                instance = cls.get_from_collected_values(ctx_vals, opt_vals)
-            else:
-                instance = cls.create_from_collected_values(ctx_vals, opt_vals)
+            instance = cls.create_from_collected_values(ctx_vals, opt_vals)
         if not instance:
             return ''
         instance.prepare_to_render(context['request'], ctx_vals, opt_vals)
@@ -134,9 +156,9 @@ class Menu:
     @classmethod
     def get_contextual_vals_from_context(cls, context):
         warnings.warn(
-            'The get_contextual_vals_from_context() class method is '
-            'deprecated in v2.12 and will be removed in v3. Use '
-            '_create_contextualvals_obj_from_context() instead.',
+            "From v2.12, the get_contextual_vals_from_context() class method "
+            "is deprecated, and will be removed in v3. Use "
+            "_create_contextualvals_obj_from_context() instead.",
             category=RemovedInWagtailMenus3Warning
         )
         return cls._create_contextualvals_obj_from_context(context)
@@ -174,8 +196,8 @@ class Menu:
     @classmethod
     def get_option_vals_from_options(cls, **kwargs):
         warnings.warn(
-            'The get_option_vals_from_options() class method is '
-            'deprecated in v2.12 and will be removed in v3. Use '
+            'From v2.12, the get_option_vals_from_options() class method is '
+            'deprecated, and will be removed in v3. Use '
             '_create_optionvals_obj_from_values() instead.',
             category=RemovedInWagtailMenus3Warning
         )
@@ -204,18 +226,6 @@ class Menu:
             "Subclasses of 'Menu' and 'django.db.models.Model' must define "
             "their own 'get_from_collected_values' method."
         )
-
-    @classmethod
-    def get_instance_for_rendering(cls, contextual_vals, option_vals):
-        warnings.warn(
-            'The get_instance_for_rendering() class method is deprecated in '
-            'v2.12 and will be removed in v3. Use create_relevant_object_from_values() '
-            'instead.', category=RemovedInWagtailMenus3Warning
-        )
-        if issubclass(cls, models.Model):
-            return cls.get_from_collected_values(contextual_vals, option_vals)
-
-        return cls.create_from_collected_values(contextual_vals, option_vals)
 
     def get_sub_menu_class(self):
         """

--- a/wagtailmenus/tests/models/menus.py
+++ b/wagtailmenus/tests/models/menus.py
@@ -17,6 +17,21 @@ class CustomChildrenMenu(ChildrenMenu):
 class CustomSectionMenu(SectionMenu):
     sub_menu_template_name = "menus/custom-overrides/section-sub.html"
 
+    @classmethod
+    def get_contextual_vals_from_context(cls, context):
+        # To be removed in v3
+        return super().get_contextual_vals_from_context(context)
+
+    @classmethod
+    def get_option_vals_from_options(cls, **kwargs):
+        # To be removed in v3
+        return super().get_option_vals_from_options(**kwargs)
+
+    @classmethod
+    def get_instance_for_rendering(cls, contextual_vals, option_vals):
+        # To be removed in v3
+        return super().get_instance_for_rendering(contextual_vals, option_vals)
+
 
 class MultilingualMenuItem(models.Model):
     link_text_de = models.CharField(
@@ -84,6 +99,11 @@ class FlatMenuCustomMenuItem(MultilingualMenuItem, AbstractFlatMenuItem):
 
 class CustomMainMenu(AbstractMainMenu):
     panels = AbstractMainMenu.content_panels + AbstractMainMenu.settings_panels
+
+    @classmethod
+    def get_instance_for_rendering(cls, contextual_vals, option_vals):
+        # To be removed in v3
+        return super().get_instance_for_rendering(contextual_vals, option_vals)
 
 
 class CustomFlatMenu(AbstractFlatMenu):

--- a/wagtailmenus/tests/models/menus.py
+++ b/wagtailmenus/tests/models/menus.py
@@ -17,21 +17,6 @@ class CustomChildrenMenu(ChildrenMenu):
 class CustomSectionMenu(SectionMenu):
     sub_menu_template_name = "menus/custom-overrides/section-sub.html"
 
-    @classmethod
-    def get_contextual_vals_from_context(cls, context):
-        # To be removed in v3
-        return super().get_contextual_vals_from_context(context)
-
-    @classmethod
-    def get_option_vals_from_options(cls, **kwargs):
-        # To be removed in v3
-        return super().get_option_vals_from_options(**kwargs)
-
-    @classmethod
-    def get_instance_for_rendering(cls, contextual_vals, option_vals):
-        # To be removed in v3
-        return super().get_instance_for_rendering(contextual_vals, option_vals)
-
 
 class MultilingualMenuItem(models.Model):
     link_text_de = models.CharField(
@@ -99,6 +84,16 @@ class FlatMenuCustomMenuItem(MultilingualMenuItem, AbstractFlatMenuItem):
 
 class CustomMainMenu(AbstractMainMenu):
     panels = AbstractMainMenu.content_panels + AbstractMainMenu.settings_panels
+
+    @classmethod
+    def get_contextual_vals_from_context(cls, context):
+        # To be removed in v3
+        return super().get_contextual_vals_from_context(context)
+
+    @classmethod
+    def get_option_vals_from_options(cls, **kwargs):
+        # To be removed in v3
+        return super().get_option_vals_from_options(**kwargs)
 
     @classmethod
     def get_instance_for_rendering(cls, contextual_vals, option_vals):

--- a/wagtailmenus/tests/models/menus.py
+++ b/wagtailmenus/tests/models/menus.py
@@ -17,6 +17,11 @@ class CustomChildrenMenu(ChildrenMenu):
 class CustomSectionMenu(SectionMenu):
     sub_menu_template_name = "menus/custom-overrides/section-sub.html"
 
+    @classmethod
+    def get_instance_for_rendering(cls, contextual_vals, option_vals):
+        # To be removed in v3
+        return super().get_instance_for_rendering(contextual_vals, option_vals)
+
 
 class MultilingualMenuItem(models.Model):
     link_text_de = models.CharField(

--- a/wagtailmenus/tests/test_custom_models.py
+++ b/wagtailmenus/tests/test_custom_models.py
@@ -218,6 +218,7 @@ class TestCustomMenuItemsFrench(TestCase):
 @override_settings(
     WAGTAILMENUS_MAIN_MENU_MODEL='tests.CustomMainMenu',
     WAGTAILMENUS_FLAT_MENU_MODEL='tests.CustomFlatMenu',
+    WAGTAILMENUS_SECTION_MENU_CLASS='wagtailmenus.tests.models.CustomSectionMenu',
 )
 class TestCustomMenuModels(TestCase):
     fixtures = ['test.json', 'test_custom_models.json']

--- a/wagtailmenus/tests/test_mainmenu_class.py
+++ b/wagtailmenus/tests/test_mainmenu_class.py
@@ -23,6 +23,17 @@ class MainMenuTestCase(TestCase):
         return MainMenu.objects.first()
 
 
+class TestMainMenuGeneralMethods(MainMenuTestCase):
+
+    def test_create_from_collected_values_is_not_implemented(self):
+        # Model-based menus use get_from_collected_values() instead of
+        # create_from_collected_values(), because existing objects are reused,
+        # rather than recreated each time
+        menu = self.get_test_menu_instance()
+        with self.assertRaises(NotImplementedError):
+            menu.create_from_collected_values(None, None)
+
+
 class TestTopLevelItems(MainMenuTestCase):
 
     # ------------------------------------------------------------------------

--- a/wagtailmenus/tests/test_sectionmenu_class.py
+++ b/wagtailmenus/tests/test_sectionmenu_class.py
@@ -12,6 +12,16 @@ class SectionMenuTestCase(TestCase):
         return SectionMenu(root_page=Page(), max_levels=3, use_specific=1)
 
 
+class TestSectionMenuGeneralMethods(SectionMenuTestCase):
+
+    def test_get_from_collected_values_is_not_implemented(self):
+        # Non model-based menus use create_from_collected_values() instead of
+        # get_from_collected_values(), because there's no 'getting' involved.
+        menu = self.get_test_menu_instance()
+        with self.assertRaises(NotImplementedError):
+            menu.get_from_collected_values(None, None)
+
+
 class TestGetSubMenuTemplateNames(
     SectionMenuTestCase, base.GetSubMenuTemplateNamesMethodTestCase
 ):


### PR DESCRIPTION
- Renames `Menu.get_contextual_vals_from_context()` to `Menu._create_contextualvals_obj_from_context()` to better indicate what the method does.
- Renames `Menu.get_option_vals_from_options()` to `Menu._create_optionvals_obj_from_values()` to better indicate what the method does.
- Replaces `Menu.get_instance_for_rendering()` with two new methods: 
  -  `Menu.get_from_collected_values()` - which is used when the menu class extends django.db.models.Model,
  - And `Menu.create_from_collected_values()`
