### PR TITLE
Safeguarding against infinite loops when using 'menuitem.sub_menu'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 * Dropped support for ``relative_url()`` methods on custom menu item models that do not support a ``request`` keyword argument.
 * Added support for Wagtail 2.3.
 * Added support for Django 2.1.
+* Updated ``MenuPage.get_repeated_menu_item()`` to nullify `sub_menu` on the copy to reduce likelihood of infinite recursion errors.
+* Updated ``Menu._prime_menu_item()`` to set `sub_menu` to None if no new value is being added, to reduce likelihood of infinite recursion errors.
 
 
 2.12 (17.11.2018)

--- a/docs/source/releases/2.13.rst
+++ b/docs/source/releases/2.13.rst
@@ -24,6 +24,8 @@ Minor changes & bug fixes
 
 - Added support for Wagtail 2.3.
 - Added support for Django 2.1.
+- Updated ``MenuPage.get_repeated_menu_item()`` to nullify ``sub_menu`` on the copy to reduce likelihood of infinite recursion errors.
+- Updated ``Menu._prime_menu_item()`` to set ``sub_menu`` to None if no new value is being added, to reduce likelihood of infinite recursion errors.
 
 
 Deprecations

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -668,6 +668,8 @@ class Menu:
 
         if item.has_children_in_menu and option_vals.add_sub_menus_inline:
             item.sub_menu = self.create_sub_menu(page)
+        else:
+            item.sub_menu = None
 
         return item
 

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -119,8 +119,9 @@ class MenuPageMixin(models.Model):
         else:
             menuitem.active_class = ''
 
-        # Set/reset 'has_children_in_menu'
+        # Set/reset 'has_children_in_menu' and 'sub_menu'
         menuitem.has_children_in_menu = False
+        menuitem.sub_menu = None
 
         return menuitem
 

--- a/wagtailmenus/tests/test_menu_class.py
+++ b/wagtailmenus/tests/test_menu_class.py
@@ -64,7 +64,7 @@ class TestGetMenuItemsForRendering(MainMenuTestCase):
         )
         self.assertGreater(len(items_with_children), 1)
         for menu_item in items_with_children:
-            self.assertFalse(hasattr(menu_item, 'sub_menu'))
+            self.assertIs(getattr(menu_item, 'sub_menu', None), None)
 
     def test_sub_menu_items_added_inline_if_option_value_set_to_true(self):
         menu = self.get_render_ready_menu_instance(add_sub_menus_inline=True)
@@ -73,5 +73,5 @@ class TestGetMenuItemsForRendering(MainMenuTestCase):
             if getattr(item, 'has_children_in_menu', False)
         )
         for menu_item in items_with_children:
-            self.assertTrue(hasattr(menu_item, 'sub_menu'))
+            self.assertTrue(menu_item.sub_menu)
             self.assertIsInstance(menu_item.sub_menu, menu.get_sub_menu_class())


### PR DESCRIPTION
If menus items happen to be being recursively generated based on whether `menuitem.sub_menu` is set instead of whether `menuitem.has_children_in_menu` is True, this can result in an an infinite loop when MenuPage objects copy themselves to add a duplicate into a sub menu (because the sub_menu from the parent get's copied to the child).

These changes ensure items only come out of `_prime_menu_item()` with a `sub_menu` added if it was intentionally added by that method.