### PR TITLE
Update Page.get_sitemap_urls() signature to match Wagtail 2.2

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@
 * Michael van de Waeter (mvdwaeter)
 * Philipp Bosch (philippbosch) (A Color Bright)
 * Oktay Altay (OktayAltay)
+* Dan Bentley (danbentley)
 
 
 ## Translators

--- a/wagtailmenus/models/pages.py
+++ b/wagtailmenus/models/pages.py
@@ -244,7 +244,7 @@ class AbstractLinkPage(Page):
             return self.link_page_is_suitable_for_display()
         return True
 
-    def get_sitemap_urls(self):
+    def get_sitemap_urls(self, request=None):
         return []  # don't include pages of this type in sitemaps
 
     def _url_base(self, request=None, current_site=None, full_url=False):


### PR DESCRIPTION
In Wagtail 2.2 Page.get_sitemap_urls() can accept the optional request argument.

Currently, sites with `AbstractLinkPage`s are unable to generate a sitemap.

https://docs.wagtail.io/en/v2.2.2/releases/2.2.html#page-get-sitemap-urls-now-accepts-an-optional-request-keyword-argument

This is a minor change that won't cause any issues with older Wagtail installs so I haven't included any unit tests but I'm happy to add if you need them.


