### PR TITLE
Optimise 'guess page from url'  logic

### DIFF
--- a/wagtailmenus/context_processors.py
+++ b/wagtailmenus/context_processors.py
@@ -1,58 +1,47 @@
 from django.http import Http404
 from django.utils.functional import SimpleLazyObject
-from wagtailmenus.conf import constants, settings
-from wagtailmenus.utils.misc import get_site_from_request
+from wagtailmenus.conf import settings
+from wagtailmenus.utils.misc import get_site_from_request, get_page_from_request
 
 
 def wagtailmenus(request):
 
-    def _get_value_dict():
+    def _get_wagtailmenus_vals():
         current_page = request.META.get('WAGTAILMENUS_CURRENT_PAGE')
         section_root = request.META.get('WAGTAILMENUS_CURRENT_SECTION_ROOT')
-        ancestor_ids = request.META.get(
-            'WAGTAILMENUS_CURRENT_PAGE_ANCESTOR_IDS')
-        match = None
         site = get_site_from_request(request, fallback_to_default=True)
+        ancestor_ids = ()
+        match = None
 
-        guess_pos = settings.GUESS_TREE_POSITION_FROM_PATH
-        sroot_depth = settings.SECTION_ROOT_DEPTH
+        guess_position = settings.GUESS_TREE_POSITION_FROM_PATH
+        section_root_depth = settings.SECTION_ROOT_DEPTH
 
-        if guess_pos and not current_page:
-            path_components = [pc for pc in request.path.split('/') if pc]
-            # Keep trying to find a page using the path components until there
-            # are no components left, or a page has been identified
-            first_run = True
-            while path_components and match is None:
-                try:
-                    match, args, kwargs = site.root_page.specific.route(
-                        request, path_components)
-                    ancestor_ids = match.get_ancestors(inclusive=True).filter(
-                        depth__gte=sroot_depth).values_list('id', flat=True)
-                    if first_run:
-                        # A page was found matching the exact path, so it's
-                        # safe to assume it's the 'current page'
-                        current_page = match
-                except Http404:
-                    # No match found, so remove a path component and try again
-                    path_components.pop()
-                first_run = False
+        if guess_position and not current_page:
+            match, full_url_match = get_page_from_request(request, site, accept_best_match=True)
+            if full_url_match:
+                current_page = match
 
-        if guess_pos and not section_root:
+        if guess_position and not section_root:
             best_match = current_page or match
             if best_match:
-                if best_match.depth == sroot_depth:
+                if best_match.depth == section_root_depth:
                     section_root = best_match
-                elif best_match.depth > sroot_depth:
-                    # Attempt to identify the section root page from best_match
+                elif best_match.depth > section_root_depth:
                     section_root = best_match.get_ancestors().filter(
-                        depth__exact=sroot_depth).first()
+                        depth__exact=section_root_depth).first()
+
+        if current_page or match:
+            page = current_page or match
+            if page.depth >= section_root_depth:
+                ancestor_ids = page.get_ancestors(inclusive=True).filter(
+                    depth__gte=section_root_depth).values_list('id', flat=True)
 
         return {
             'current_page': current_page,
             'section_root': section_root,
-            'current_page_ancestor_ids': ancestor_ids or (),
+            'current_page_ancestor_ids': ancestor_ids,
         }
 
     return {
-        'wagtailmenus_vals': SimpleLazyObject(_get_value_dict),
+        'wagtailmenus_vals': SimpleLazyObject(_get_wagtailmenus_vals),
     }

--- a/wagtailmenus/utils/misc.py
+++ b/wagtailmenus/utils/misc.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from wagtail.core.models import Page, Site
 
 from wagtailmenus.models.menuitems import MenuItem
@@ -9,6 +10,54 @@ def get_site_from_request(request, fallback_to_default=True):
     if fallback_to_default:
         return Site.objects.filter(is_default_site=True).first()
     return None
+
+
+def get_page_from_request(request, site, accept_best_match=True):
+    """
+    Attempts to find a ``Page`` within ``site`` for the supplied
+    ``request``. Returns a tuple, where the first element is the matching
+    ``Page`` object (or ``None`` if no match was found), and a boolean
+    indicating whether the page matched the full URL.
+
+    If ``accept_best_match`` is ``True``, and a page cannot be found
+    matching the full URL, the method will attempt to find a 'best match'
+    for the request instead.
+    """
+    routing_point = site.root_page.specific
+    path_components = [pc for pc in request.path.split('/') if pc]
+
+    if not accept_best_match:
+        # Attempt to find a full URL match, or give up
+        try:
+            return routing_point.route(request, path_components)[0], True
+        except Http404:
+            return None, False
+
+    best_match = None
+    full_url_match = False
+    lookup_components = []
+
+    # Keep trying to route() until path components are exhausted
+    for i, component in enumerate(path_components, 1):
+        lookup_components.append(component)
+        try:
+            best_match = routing_point.route(request, lookup_components)[0]
+            full_url_match = bool(i == len(path_components))
+            if best_match != routing_point:
+                # A new page was reached. Next time, try routing from this new
+                # page, using a single lookup component
+                routing_point = best_match
+                lookup_components = []
+            else:
+                # It looks like `routing_point` has multiple routes. Next time,
+                # try routing from the same page with more components
+                continue
+        except Http404:
+            # No luck this time, but keep trying with more components until
+            # a new page is reached, or there are no components left.
+            continue
+
+    return best_match, full_url_match
 
 
 def validate_supplied_values(tag, max_levels=None, parent_page=None,


### PR DESCRIPTION
When not serving a page via Wagtail's `serve()` view, and the `WAGTAILMENUS_GUESS_TREE_POSITION_FROM_PATH` setting it `True`, wagtailmenus attempts to find a matching `Page` which can help keep active class application and section menus working. 

It uses the `Page.route()` mechanism to do this, but when a 'best match' will do, the current approach of starting with the full path and routing from the site root page with fewer and fewer segments is quite inefficient, because the process must start from scratch (at the site root) each time.

This approach uses `Page.route()` in a more 'progressive' way, make progress one page at a time, and not giving up until all URL segments are exhausted. This way, when routing fails to make any more progress, we can still make use of the last successful attempt.