### PR TITLE
Django v3.0 has removed private Python 2 compatibility APIs, one of them is django.utils.six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ branch_url = "%stree/stable/%s" % (base_url, stable_branch_name)
 
 # Essential dependencies
 requires = [
-    'django-cogwheels==0.3',
+    'django-cogwheels==0.3', 'six',
 ]
 
 testing_extras = [

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1,3 +1,4 @@
+import six
 import warnings
 from collections import defaultdict, namedtuple, OrderedDict
 from types import GeneratorType
@@ -6,7 +7,6 @@ from django.db import models
 from django.db.models import BooleanField, Case, Q, When
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import get_template, select_template
-from django.utils import six
 from django.utils.functional import cached_property, lazy
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
The latest version of `Wagtail` is compatible with Django 2.1, 2.2 and 3.0, however the `wagtailmenus` was not, at least because of the #354.