### PR TITLE
Remove six dependency

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,7 +20,7 @@
 * Philipp Bosch (philippbosch) (A Color Bright)
 * Oktay Altay (OktayAltay)
 * Dan Bentley (danbentley)
-
+* Arkadiusz Michał Ryś (ArkadiuszMichalRys)
 
 ## Translators
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 base_url = "https://github.com/rkhleics/wagtailmenus/"
-dowload_url = '%starball/v%s' % (base_url, __version__)
+download_url = '%starball/v%s' % (base_url, __version__)
 branch_url = "%stree/stable/%s" % (base_url, stable_branch_name)
 
 # Essential dependencies
@@ -24,7 +24,7 @@ testing_extras = [
 ]
 
 development_extras = [
-    'wagtail>=2.4,<2.5',
+    'wagtail>=2.4,<2.9',
     'django-debug-toolbar',
     'django-extensions',
     'ipdb',
@@ -53,7 +53,7 @@ setup(
     packages=find_packages(),
     license="MIT",
     keywords="wagtail cms model utility",
-    download_url=dowload_url,
+    download_url=download_url,
     url=branch_url,
     include_package_data=True,
     zip_safe=False,
@@ -72,6 +72,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 3.0',
         'Framework :: Wagtail :: 2',
         'Topic :: Internet :: WWW/HTTP',
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -6,7 +6,6 @@ from django.db import models
 from django.db.models import BooleanField, Case, Q, When
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import get_template, select_template
-from django.utils import six
 from django.utils.functional import cached_property, lazy
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -22,7 +21,7 @@ from .mixins import DefinesSubMenuTemplatesMixin
 from .pages import AbstractLinkPage
 
 
-mark_safe_lazy = lazy(mark_safe, six.text_type)
+mark_safe_lazy = lazy(mark_safe, str)
 
 ContextualVals = namedtuple('ContextualVals', (
     'parent_context',


### PR DESCRIPTION
Fixes #354 by removing the six import and use.
Should make wagtail 2.8 compatible (with django 3.0.x).