### PR TITLE
Wagtail splits the settings out to base, dev, and prod

### DIFF
--- a/docs/source/advanced_topics/custom_menu_classes.rst
+++ b/docs/source/advanced_topics/custom_menu_classes.rst
@@ -177,7 +177,7 @@ If you also need to override the ``MainMenu`` model, that's possible too. But, b
 
     .. code-block:: python
 
-        # settings.py
+        # e.g. settings/base.py
 
         WAGTAILMENUS_MAIN_MENU_MODEL = "appname.LimitedMainMenu"
 
@@ -262,7 +262,7 @@ If you're happy with the default ``FlatMenu`` model, but wish customise the menu
 
     .. code-block:: python
 
-        # settings.py
+        # e.g. settings/base.py
 
         # Use the 'related_name' attribute you used on your custom model's ParentalKey field
         WAGTAILMENUS_FLAT_MENU_ITEMS_RELATED_NAME = "custom_menu_items"
@@ -411,7 +411,7 @@ If you also need to override the ``FlatMenu`` model, that's possible too. But, b
 
     .. code-block:: python
 
-        # settings.py
+        # e.g. settings/base.py
 
         WAGTAILMENUS_FLAT_MENU_MODEL = "appname.TranslatedFlatMenu"
 
@@ -453,7 +453,7 @@ The class ``wagtailmenus.models.menus.SectionMenu`` is used by default, but you 
 
 .. code-block:: python
 
-    # settings.py
+    # e.g. settings/base.py
 
     WAGTAILMENUS_SECTION_MENU_CLASS = "mysite.appname.models.CustomSectionMenu"
 
@@ -487,7 +487,7 @@ The class ``wagtailmenus.models.menus.ChildrenMenu`` is used by default, but you
 
 .. code-block:: python
 
-    # settings.py
+    # e.g. settings/base.py
 
     WAGTAILMENUS_CHILDREN_MENU_CLASS = "mysite.appname.models.CustomChildrenMenu"
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,7 +14,7 @@ Installing wagtailmenus
     ``INSTALLED_APPS`` setting in your project settings:
 
     .. code-block:: python
-        :caption: settings.py
+        :caption: e.g. settings/base.py
 
         INSTALLED_APPS = [
             ...
@@ -27,7 +27,7 @@ Installing wagtailmenus
     should look something like this:
 
     .. code-block:: python
-        :caption: settings.py
+        :caption: e.g. settings/base.py
         :emphasize-lines: 19
 
         TEMPLATES = [

--- a/docs/source/settings_reference.rst
+++ b/docs/source/settings_reference.rst
@@ -50,7 +50,7 @@ For example, if your project uses an 'info' menu in the header, a 'footer' menu 
 
 .. code-block:: python
 
-    # settings.py
+    # e.g. settings/base.py
 
     WAGTAILMENUS_FLAT_MENUS_HANDLE_CHOICES = (
         ('info', 'Info'),
@@ -80,7 +80,7 @@ If you wish to override the ``ModelAdmin`` class used to represent **'Flat menus
 
 .. code-block:: python
 
-    # settings.py
+    # e.g. settings/base.py
 
     WAGTAILMENUS_FLAT_MENUS_MODELADMIN_CLASS = "projectname.appname.modulename.ClassName"
 
@@ -119,7 +119,7 @@ If you wish to override the ``ModelAdmin`` class used to represent **'Main menus
 
 .. code-block:: python
 
-    # settings.py
+    # e.g. settings/base.py
 
     WAGTAILMENUS_MAIN_MENUS_MODELADMIN_CLASS = "projectname.appname.modulename.ClassName"
 
@@ -192,7 +192,7 @@ If you have a multi-site project, and want to be able to use different templates
 
 .. code-block:: python
 
-    # settings.py
+    # e.g. settings/base.py
 
     WAGTAILMENUS_SITE_SPECIFIC_TEMPLATE_DIRS = True
 


### PR DESCRIPTION
Some confusion from people recently using wagtailmenus led to creating a settings.py file

ref https://docs.wagtail.io/en/v2.9/reference/project_template.html?highlight=base.py#django-settings

