### PR TITLE
Update wagtail imports

### DIFF
--- a/docs/source/advanced_topics/custom_menu_classes.rst
+++ b/docs/source/advanced_topics/custom_menu_classes.rst
@@ -208,7 +208,7 @@ If you're happy with the default ``FlatMenu`` model, but wish customise the menu
         from django.db import models
         from django.utils.translation import ugettext_lazy as _
         from modelcluster.fields import ParentalKey
-        from wagtail.iamges import get_image_model_string
+        from wagtail.images import get_image_model_string
         from wagtail.images.edit_handlers import ImageChooserPanel
         from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
         from wagtailmenus.models import AbstractFlatMenuItem

--- a/docs/source/advanced_topics/custom_menu_classes.rst
+++ b/docs/source/advanced_topics/custom_menu_classes.rst
@@ -33,9 +33,9 @@ If you're happy with the default ``MainMenu`` model, but wish customise the menu
         from django.db import models
         from django.utils.translation import ugettext_lazy as _
         from modelcluster.fields import ParentalKey
-        from wagtail.wagtailimages import get_image_model_string
-        from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
-        from wagtail.wagtailadmin.edit_handlers import FieldPanel, PageChooserPanel
+        from wagtail.images import get_image_model_string
+        from wagtail.images.edit_handlers import ImageChooserPanel
+        from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
         from wagtailmenus.models import AbstractMainMenuItem
 
 
@@ -113,7 +113,7 @@ If you also need to override the ``MainMenu`` model, that's possible too. But, b
         from django.utils.translation import ugettext_lazy as _
         from django.utils import timezone
         from modelcluster.fields import ParentalKey
-        from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
+        from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
         from wagtailmenus.conf import settings
         from wagtailmenus.models import AbstractMainMenu, AbstractMainMenuItem
 
@@ -208,9 +208,9 @@ If you're happy with the default ``FlatMenu`` model, but wish customise the menu
         from django.db import models
         from django.utils.translation import ugettext_lazy as _
         from modelcluster.fields import ParentalKey
-        from wagtail.wagtailimages import get_image_model_string
-        from wagtail.wagtailimages.edit_handlers import ImageChooserPanel
-        from wagtail.wagtailadmin.edit_handlers import FieldPanel, PageChooserPanel
+        from wagtail.iamges import get_image_model_string
+        from wagtail.images.edit_handlers import ImageChooserPanel
+        from wagtail.admin.edit_handlers import FieldPanel, PageChooserPanel
         from wagtailmenus.models import AbstractFlatMenuItem
 
 
@@ -289,7 +289,7 @@ If you also need to override the ``FlatMenu`` model, that's possible too. But, b
         from django.utils import translation
         from django.utils.translation import ugettext_lazy as _
         from modelcluster.fields import ParentalKey
-        from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
+        from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel, PageChooserPanel
         from wagtailmenus.conf import settings
         from wagtailmenus.panels import FlatMenuItemsInlinePanel
         from wagtailmenus.models import AbstractFlatMenu, AbstractFlatMenuItem
@@ -437,7 +437,7 @@ The class ``wagtailmenus.models.menus.SectionMenu`` is used by default, but you 
     # mysite/appname/models.py
 
     from django.utils.translation import ugettext_lazy as _
-    from wagtail.wagtailcore.models import Page
+    from wagtail.core.models import Page
     from wagtailmenus.models import SectionMenu
 
 
@@ -472,7 +472,7 @@ The class ``wagtailmenus.models.menus.ChildrenMenu`` is used by default, but you
     # appname/menus.py
 
     from django.utils.translation import ugettext_lazy as _
-    from wagtail.wagtailcore.models import Page
+    from wagtail.core.models import Page
     from wagtailmenus.models import ChildrenMenu
 
 

--- a/docs/source/advanced_topics/hooks.rst
+++ b/docs/source/advanced_topics/hooks.rst
@@ -11,7 +11,7 @@ Registering functions with a Wagtail hook is done through the ``@hooks.register`
 
 .. code-block:: python
 
-  from wagtail.wagtailcore import hooks
+  from wagtail.core import hooks
 
   @hooks.register('name_of_hook')
   def my_hook_function(arg1, arg2...)
@@ -63,7 +63,7 @@ However, if you'd like to filter this result down further, you can do so using s
 
 .. code-block:: python
 
-    from wagtail.wagtailcore import hooks
+    from wagtail.core import hooks
 
     @hooks.register('menus_modify_base_page_queryset')
     def make_some_changes(
@@ -86,7 +86,7 @@ Or, if you only wanted to change the queryset for a menu of a specific type, you
 
 .. code-block:: python
 
-    from wagtail.wagtailcore import hooks
+    from wagtail.core import hooks
 
     @hooks.register('menus_modify_base_page_queryset')
     def make_some_changes(
@@ -124,7 +124,7 @@ However, if you'd only like to include a subset of the CMS-defined menu item, or
 
 .. code-block:: python
 
-    from wagtail.wagtailcore import hooks
+    from wagtail.core import hooks
 
     @hooks.register('menus_modify_base_menuitem_queryset')
     def make_some_changes(
@@ -149,7 +149,7 @@ These changes would be applied to all menu types that use menu items to define t
 
 .. code-block:: python
 
-    from wagtail.wagtailcore import hooks
+    from wagtail.core import hooks
 
     @hooks.register('menus_modify_base_menuitem_queryset')
     def make_some_changes(
@@ -193,7 +193,7 @@ This hook allows you to modify the list **before** it is 'primed' (a process tha
 
 .. code-block:: python
 
-    from wagtail.wagtailcore import hooks
+    from wagtail.core import hooks
 
     @hooks.register('menus_modify_raw_menu_items')
     def make_some_changes(
@@ -233,7 +233,7 @@ This hook allows you to modify the list of items **after** they have been 'prime
 
 .. code-block:: python
 
-    from wagtail.wagtailcore import hooks
+    from wagtail.core import hooks
 
     @hooks.register('menus_modify_primed_menu_items')
     def make_some_changes(

--- a/docs/source/advanced_topics/hooks.rst
+++ b/docs/source/advanced_topics/hooks.rst
@@ -76,7 +76,7 @@ However, if you'd like to filter this result down further, you can do so using s
         """
         if not request.user.is_authenticated():
             return queryset.none()
-        return queryset.filter(owner=self.request.user)
+        return queryset.filter(owner=request.user)
 
 
 This would ensure that only pages 'owned' by currently logged-in user will appear in menus. And the changes will be applied to ALL types of menu, regardless of what template tag is being called to do the rendering.
@@ -101,7 +101,7 @@ Or, if you only wanted to change the queryset for a menu of a specific type, you
         if menu_type in ('main_menu', 'flat_menu'):
             if not request.user.is_authenticated():
                 return queryset.none()
-            queryset = queryset.filter(owner=self.request.user)
+            queryset = queryset.filter(owner=request.user)
 
         return queryset  # always return a queryset
 

--- a/docs/source/menupage.rst
+++ b/docs/source/menupage.rst
@@ -158,7 +158,7 @@ Wagtail has a restriction that forbids models from subclassing more than one oth
         
         # appname/models.py
 
-        from wagtail.wagtailforms.models import AbstractEmailForm
+        from wagtail.contrib.forms.models import AbstractEmailForm
         from wagtailmenus.models import MenuPageMixin
         from wagtailmenus.panels import menupage_panel
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -203,7 +203,7 @@ Solves the problem of important page links becoming just 'toggles' in multi-leve
 =======================================================================================
 
 Extend the ``wagtailmenus.models.MenuPage`` model instead of the usual
-``wagtail.wagtailcore.models.Page`` model to create your custom page types, and gain a
+``wagtail.core.models.Page`` model to create your custom page types, and gain a
 couple of extra fields that will allow you to configure certain pages to appear again
 alongside their children in multi-level menus. Use the menu tags provided, and that
 behaviour will remain consistent in all menus throughout your site. To find out more,

--- a/docs/source/releases/2.4.0.rst
+++ b/docs/source/releases/2.4.0.rst
@@ -33,7 +33,7 @@ New ``use_absolute_page_urls`` parameter added to template tags
 
 The new parameter allows you to render menus that use 'absolute' URLs
 for pages (including the protocol/domain derived from the relevant 
-``wagtailcore.models.Site`` object), instead of the 'relative' URLs used by
+``wagtail.core.models.Site`` object), instead of the 'relative' URLs used by
 default.
 
 


### PR DESCRIPTION
I've updated the documentation to match the module path changes made in Wagtail 2.0.
 https://github.com/wagtail/wagtail/blob/882f8f3cf8ddd79c30e611a48882b309e90dad0c/docs/releases/2.0.rst#wagtail-module-path-updates

I left the reference to `wagtailcore` in the `2.1.2` release notes since the module path was accurate at the time though happy to update that too.

https://github.com/rkhleics/wagtailmenus/blob/master/docs/source/releases/2.1.2.rst

Additionally, I've fixed an issue in the hook example code. Happy to break out into a separate PR if you prefer.

Thanks!
