### PR TITLE
Potential fix for Wagtail 3

### DIFF
--- a/wagtailmenus/views.py
+++ b/wagtailmenus/views.py
@@ -54,9 +54,6 @@ class MenuTabbedInterfaceMixin:
                 ObjectList(self.model.settings_panels, heading=_("Settings"),
                            classname="settings"),
             ])
-        if hasattr(edit_handler, 'bind_to'):
-            # For Wagtail>=2.5
-            return edit_handler.bind_to(model=self.model)
         return edit_handler.bind_to_model(self.model)
 
     def form_invalid(self, form):


### PR DESCRIPTION
Based on suggestions by @amajai in #421: https://github.com/jazzband/wagtailmenus/issues/421#issuecomment-1148720271

This is a 'just enough' fork to allow Wagtail 3 installs to get back to functioning. I can't guarantee it works fully, but it does seem to work enough to edit existing menus. There's probably a better fix for this that keeps compatibility for `wagtail >= 2.5`

<img width="1095" alt="Screenshot 2022-06-13 at 16 53 19" src="https://user-images.githubusercontent.com/237556/173394346-8049f7ec-7ba3-4a3d-929d-aae24abfa0e3.png">

I also ran `wagtail updatemodulepaths --list` but couldn't get it to run, so I'm leaving the report here:

```
(.venv) jan@Jans-MacBook-Pro wagtailmenus % wagtail updatemodulepaths ./wagtailmenus --list
wagtail_hooks.py - 1 change
views.py - 2 changes
panels.py - 1 change
templatetags/menu_tags.py - 1 change
settings/base.py - 1 change
tests/test_backend.py - 2 changes
tests/test_menu_items.py - 1 change
tests/test_base_menu_classes.py - 1 change
tests/test_menu_rendering.py - 1 change
tests/test_page_models.py - 1 change
tests/test_hooks.py - 1 change
tests/utils.py - 2 changes
tests/test_commands.py - 1 change
tests/urls.py - 1 change
tests/models/pages.py - 2 changes
tests/models/menus.py - 1 change
management/commands/autopopulate_main_menus.py - 1 change
utils/misc.py - 1 change
utils/inspection.py - 1 change
utils/tests/test_misc.py - 4 changes
models/pages.py - 1 change
models/menus.py - 2 changes
models/menuitems.py - 2 changes

Checked 103 .py files, 23 files to update.
```
