### PR TITLE
feat: Add LOCALIZE_MENU_ITEMS setting for i18n locale-aware menus (fixes #242)

### DIFF
--- a/docs/source/settings_reference.rst
+++ b/docs/source/settings_reference.rst
@@ -392,3 +392,44 @@ Use this to specify the 'depth' value of a project's 'section root' pages. For m
 Default value: ``False``
 
 By default, menu items linking to custom URLs are attributed with the 'active' class only if their ``link_url`` value matches the path of the current request _exactly_. Setting this to `True` in your project's settings will enable a smarter approach to active class attribution for custom URLs, where only the 'path' part of the ``link_url`` value is used to determine what active class should be used. The new approach will also attribute the  'ancestor'  class to menu items if the ``link_url`` looks like an ancestor of the current request URL.
+
+
+.. _LOCALIZE_MENU_ITEMS:
+
+``WAGTAILMENUS_LOCALIZE_MENU_ITEMS``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Default value: ``False`` (or ``True`` when ``WAGTAIL_I18N_ENABLED = True``)
+
+When enabled, wagtailmenus will resolve each menu item's ``link_page`` to its
+translation in the currently active locale at render time, so that menu item
+titles and URLs automatically reflect the visitor's language without any
+additional configuration.
+
+If ``WAGTAIL_I18N_ENABLED`` is set to ``True`` in your project's settings,
+this feature is **enabled automatically** — you do not need to set
+``WAGTAILMENUS_LOCALIZE_MENU_ITEMS`` explicitly. You can still opt out by
+setting it to ``False`` even when ``WAGTAIL_I18N_ENABLED`` is ``True``.
+
+.. code-block:: python
+
+    # e.g. settings/base.py
+
+    # Opt in explicitly (not required if WAGTAIL_I18N_ENABLED = True):
+    WAGTAILMENUS_LOCALIZE_MENU_ITEMS = True
+
+    # Opt out even when WAGTAIL_I18N_ENABLED = True:
+    WAGTAILMENUS_LOCALIZE_MENU_ITEMS = False
+
+When active, menu items stored against a default-locale page will be displayed
+using the equivalent page in the active locale (if a translation exists).
+If no translation is found for the active locale, the original page is used as
+a fallback. The localization is applied **at render time only** — the stored
+``link_page`` foreign key on the menu item is never modified.
+
+.. NOTE::
+    This feature requires `wagtail-localize <https://github.com/wagtail/wagtail-localize>`_
+    (or another package that provides ``Page.localized``) to be installed, and
+    pages to be translated via Wagtail's standard translation mechanism.
+    Menu items are configured once (against the default-locale pages) and the
+    correct locale is resolved automatically on each request.

--- a/wagtailmenus/conf/defaults.py
+++ b/wagtailmenus/conf/defaults.py
@@ -75,6 +75,8 @@ SECTION_MENU_CLASS = 'wagtailmenus.models.SectionMenu'
 # Miscellaneous settings
 # ----------------------
 
+LOCALIZE_MENU_ITEMS = False
+
 ACTIVE_CLASS = 'active'
 
 ACTIVE_ANCESTOR_CLASS = 'ancestor'

--- a/wagtailmenus/conf/settings.py
+++ b/wagtailmenus/conf/settings.py
@@ -1,10 +1,19 @@
 import sys
 
+from django.conf import settings as django_settings
 from cogwheels import BaseAppSettingsHelper
 
 
 class WagtailmenusSettingsHelper(BaseAppSettingsHelper):
     deprecations = ()
+
+    def __getattr__(self, name):
+        value = super().__getattr__(name)
+        # Auto-detect locale-awareness from Wagtail's own i18n flag when the
+        # wagtailmenus-specific setting has not been explicitly overridden.
+        if name == 'LOCALIZE_MENU_ITEMS' and not value and not self.is_overridden('LOCALIZE_MENU_ITEMS'):
+            return bool(getattr(django_settings, 'WAGTAIL_I18N_ENABLED', False))
+        return value
 
 
 sys.modules[__name__] = WagtailmenusSettingsHelper()

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -77,6 +77,13 @@ class AbstractMenuItem(models.Model, MenuItem):
         verbose_name_plural = _("menu items")
         ordering = ('sort_order',)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if settings.LOCALIZE_MENU_ITEMS and self.link_page_id and self.link_page:
+            localized = self.link_page.localized
+            if localized is not None:
+                self.link_page = localized
+
     @property
     def menu_text(self):
         if self.link_text:

--- a/wagtailmenus/models/menuitems.py
+++ b/wagtailmenus/models/menuitems.py
@@ -77,13 +77,6 @@ class AbstractMenuItem(models.Model, MenuItem):
         verbose_name_plural = _("menu items")
         ordering = ('sort_order',)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if settings.LOCALIZE_MENU_ITEMS and self.link_page_id and self.link_page:
-            localized = self.link_page.localized
-            if localized is not None:
-                self.link_page = localized
-
     @property
     def menu_text(self):
         if self.link_text:

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -963,6 +963,11 @@ class MenuWithMenuItems(ClusterableModel, Menu):
         # allow this query result to be reused by get_pages_for_display()
         self._raw_menu_items = menu_items
 
+        # pages_for_display triggers get_pages_for_display(), which populates
+        # self._localize_id_map when LOCALIZE_MENU_ITEMS is active.
+        pages = self.pages_for_display
+        localize_map = getattr(self, '_localize_id_map', {})
+
         top_level_items = []
         for item in menu_items:
 
@@ -971,10 +976,14 @@ class MenuWithMenuItems(ClusterableModel, Menu):
                 top_level_items.append(item)
                 continue
 
+            # Translate the stored (default-locale) FK to the active-locale id
+            # when localization is active, without mutating item.link_page_id.
+            lookup_id = localize_map.get(item.link_page_id, item.link_page_id)
+
             # But, we only want to include links to pages if the page was
             # in the get_pages_for_display() result
             try:
-                item.link_page = self.pages_for_display[item.link_page_id]
+                item.link_page = pages[lookup_id]
                 top_level_items.append(item)
             except KeyError:
                 continue
@@ -996,32 +1005,46 @@ class MenuWithMenuItems(ClusterableModel, Menu):
         # Start with an empty queryset, and expand as needed
         queryset = Page.objects.none()
 
+        # When localization is active, record a mapping of stored (default-locale)
+        # page ID → active-locale page ID so that get_top_level_items() can look
+        # up pages in pages_for_display using the right key without mutating the
+        # stored FK on the menu item.
+        localize_id_map = {}
+
         for item in (item for item in menu_items if item.link_page):
+            if settings.LOCALIZE_MENU_ITEMS:
+                # Resolve the active-locale page without touching item.link_page
+                # (avoids persisting the swap via admin save).
+                effective_page = item.link_page.localized or item.link_page
+                if effective_page.pk != item.link_page.pk:
+                    localize_id_map[item.link_page.pk] = effective_page.pk
+            else:
+                effective_page = item.link_page
+
             if(
                 item.allow_subnav and
-                item.link_page.depth >= settings.SECTION_ROOT_DEPTH
+                effective_page.depth >= settings.SECTION_ROOT_DEPTH
             ):
                 # Add this branch to the overall `queryset`
                 queryset = queryset | Page.objects.filter(
-                    path__startswith=item.link_page.path,
-                    depth__lt=item.link_page.depth + self.max_levels,
+                    path__startswith=effective_page.path,
+                    depth__lt=effective_page.depth + self.max_levels,
                 )
             else:
                 # Add this page only to the overall `queryset`
-                queryset = queryset | Page.objects.filter(id=item.link_page_id)
+                queryset = queryset | Page.objects.filter(id=effective_page.pk)
+
+        # Store the mapping so get_top_level_items() can translate lookup keys.
+        self._localize_id_map = localize_id_map
 
         if settings.LOCALIZE_MENU_ITEMS:
-            # When menu items have been swapped to their localized counterparts
-            # (see AbstractMenuItem.__init__), item.link_page and
-            # item.link_page_id already refer to the active-locale page, so
-            # `queryset` contains localized pages.  get_base_page_queryset()
-            # however filters on show_in_menus=True etc. and may not include
-            # the localized pages (e.g. if show_in_menus was not propagated to
-            # translations).  Bridge the gap by resolving each base page's
-            # localized counterpart and collecting their IDs.
-            base_qs = self.get_base_page_queryset()
-            suitable_ids = [p.localized.id for p in base_qs]
-            queryset = queryset.filter(id__in=suitable_ids)
+            # `queryset` already contains the localized pages.
+            # Apply the same live/show_in_menus/expired constraints as
+            # get_base_page_queryset() but only against the small set of pages
+            # in `queryset` (scales with menu size, not site size).
+            queryset = self.get_base_page_queryset().filter(
+                id__in=queryset.values('id')
+            )
         else:
             # Filter out pages unsuitable for display
             queryset = self.get_base_page_queryset() & queryset

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1010,8 +1010,21 @@ class MenuWithMenuItems(ClusterableModel, Menu):
                 # Add this page only to the overall `queryset`
                 queryset = queryset | Page.objects.filter(id=item.link_page_id)
 
-        # Filter out pages unsutable display
-        queryset = self.get_base_page_queryset() & queryset
+        if settings.LOCALIZE_MENU_ITEMS:
+            # When menu items have been swapped to their localized counterparts
+            # (see AbstractMenuItem.__init__), item.link_page and
+            # item.link_page_id already refer to the active-locale page, so
+            # `queryset` contains localized pages.  get_base_page_queryset()
+            # however filters on show_in_menus=True etc. and may not include
+            # the localized pages (e.g. if show_in_menus was not propagated to
+            # translations).  Bridge the gap by resolving each base page's
+            # localized counterpart and collecting their IDs.
+            base_qs = self.get_base_page_queryset()
+            suitable_ids = [p.localized.id for p in base_qs]
+            queryset = queryset.filter(id__in=suitable_ids)
+        else:
+            # Filter out pages unsuitable for display
+            queryset = self.get_base_page_queryset() & queryset
 
         # Always return 'specific' page instances
         return queryset.specific()

--- a/wagtailmenus/tests/test_localization.py
+++ b/wagtailmenus/tests/test_localization.py
@@ -14,7 +14,7 @@ These tests verify that when `WAGTAILMENUS_LOCALIZE_MENU_ITEMS = True` (or
 - All existing behaviour is preserved when the setting is disabled.
 """
 
-from unittest.mock import PropertyMock, patch
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from wagtail.models import Page
@@ -78,80 +78,108 @@ class TestLocalizationSetting(TestCase):
 
 
 # ---------------------------------------------------------------------------
-# 2.  AbstractMenuItem.__init__ locale swap
+# 2.  get_top_level_items() locale swap (render-time, not __init__-time)
 # ---------------------------------------------------------------------------
 
-class TestMenuItemLocalizationInit(TestCase):
-    """AbstractMenuItem.__init__ swaps link_page to its localized version."""
+class TestMenuItemLocalizationRenderTime(TestCase):
+    """
+    Localization is applied at render time by get_top_level_items(), not in
+    AbstractMenuItem.__init__. This means the stored FK is never mutated so
+    admin saves cannot accidentally persist the swapped value.
+    """
 
     fixtures = ['test.json']
 
-    def _two_distinct_pages(self):
-        pages = list(Page.objects.all().order_by('id')[:2])
-        self.assertEqual(len(pages), 2)
-        original, localized = pages
-        self.assertNotEqual(original.pk, localized.pk)
-        return original, localized
-
     # --- disabled (default) -------------------------------------------------
 
-    def test_init_does_not_swap_when_disabled(self):
-        original, localized = self._two_distinct_pages()
-        menu = MainMenu.objects.first()
+    def test_top_level_items_link_page_unchanged_when_disabled(self):
+        """When the feature is off, link_page is whatever is stored."""
+        menu = MainMenu.objects.get(pk=1)
+        first_item = menu.get_menu_items_manager().filter(
+            link_page__isnull=False
+        ).first()
+        item_pk = first_item.pk
+        original_page_pk = first_item.link_page_id
 
-        mapping = _LocalizedMapping({original.pk: localized})
+        # Even with a localization mapping active, link_page must not be swapped
+        other_page = Page.objects.exclude(pk=original_page_pk).filter(
+            live=True, expired=False, show_in_menus=True
+        ).first()
+        mapping = _LocalizedMapping({original_page_pk: other_page})
         with patch.object(Page, 'localized', mapping):
-            item = MainMenuItem(menu=menu, link_page=original)
+            items = menu.get_top_level_items()
 
-        # link_page must stay as the original when the feature is off
-        self.assertEqual(item.link_page.pk, original.pk)
+        # Identify the item by its menu item pk (stable; not the page FK)
+        matched = [i for i in items if getattr(i, 'pk', None) == item_pk]
+        self.assertTrue(len(matched) > 0)
+        self.assertEqual(matched[0].link_page.pk, original_page_pk)
 
     # --- enabled ------------------------------------------------------------
 
     @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
-    def test_init_swaps_link_page_when_enabled(self):
-        original, localized = self._two_distinct_pages()
-        menu = MainMenu.objects.first()
+    def test_top_level_items_link_page_swapped_when_enabled(self):
+        """When localization is on, item.link_page is set to the localized page."""
+        menu = MainMenu.objects.get(pk=1)
+        first_item = menu.get_menu_items_manager().filter(
+            link_page__isnull=False
+        ).first()
+        item_pk = first_item.pk  # stable menu item pk, not the page FK
+        en_page = first_item.link_page
+        it_page = Page.objects.exclude(pk=en_page.pk).filter(
+            live=True, expired=False, show_in_menus=True
+        ).first()
 
-        mapping = _LocalizedMapping({original.pk: localized})
+        mapping = _LocalizedMapping({en_page.pk: it_page})
         with patch.object(Page, 'localized', mapping):
-            item = MainMenuItem(menu=menu, link_page=original)
+            items = menu.get_top_level_items()
 
-        self.assertEqual(item.link_page.pk, localized.pk)
+        # After the swap, link_page_id is updated to it_page.pk by Django's FK
+        # descriptor, so identify the item by its stable menu item pk instead.
+        matched = [i for i in items if getattr(i, 'pk', None) == item_pk]
+        self.assertTrue(len(matched) > 0)
+        self.assertEqual(matched[0].link_page.pk, it_page.pk)
 
     @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
-    def test_init_updates_link_page_id_after_swap(self):
-        """Django FK descriptor must keep link_page_id in sync."""
-        original, localized = self._two_distinct_pages()
-        menu = MainMenu.objects.first()
+    def test_stored_link_page_id_not_mutated_by_render(self):
+        """The FK column (link_page_id) must not change after get_top_level_items()."""
+        menu = MainMenu.objects.get(pk=1)
+        first_item = menu.get_menu_items_manager().filter(
+            link_page__isnull=False
+        ).first()
+        en_page = first_item.link_page
+        it_page = Page.objects.exclude(pk=en_page.pk).filter(
+            live=True, expired=False, show_in_menus=True
+        ).first()
 
-        mapping = _LocalizedMapping({original.pk: localized})
+        mapping = _LocalizedMapping({en_page.pk: it_page})
         with patch.object(Page, 'localized', mapping):
-            item = MainMenuItem(menu=menu, link_page=original)
+            menu.get_top_level_items()
 
-        # link_page_id is the FK column; after the swap it must point at the
-        # localized page so that pages_for_display keying works correctly.
-        self.assertEqual(item.link_page_id, localized.pk)
+        # Re-read the item from DB: the FK must still be the original en page
+        stored = menu.get_menu_items_manager().get(pk=first_item.pk)
+        self.assertEqual(stored.link_page_id, en_page.pk)
 
     @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
-    def test_init_does_not_swap_when_already_in_active_locale(self):
-        """When localized returns the same page, nothing changes."""
-        original, _ = self._two_distinct_pages()
-        menu = MainMenu.objects.first()
-
-        # No mapping entry → descriptor returns the same page
+    def test_top_level_items_unchanged_when_already_in_active_locale(self):
+        """When localized returns the same page (already active locale), nothing changes."""
+        menu = MainMenu.objects.get(pk=1)
+        # Empty mapping → all pages return themselves
         mapping = _LocalizedMapping({})
         with patch.object(Page, 'localized', mapping):
-            item = MainMenuItem(menu=menu, link_page=original)
-
-        self.assertEqual(item.link_page.pk, original.pk)
+            items = menu.get_top_level_items()
+        self.assertEqual(len(items), 5)
 
     @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
-    def test_init_no_op_when_link_page_is_none(self):
-        """Items with no link_page (custom URL items) are unaffected."""
-        menu = MainMenu.objects.first()
-        item = MainMenuItem(menu=menu, link_url='/custom/', link_text='Custom')
-        self.assertIsNone(item.link_page)
+    def test_top_level_items_no_op_when_link_page_is_none(self):
+        """Custom URL items (no link_page) are always included unchanged."""
+        menu = MainMenu.objects.get(pk=1)
+        mapping = _LocalizedMapping({})
+        with patch.object(Page, 'localized', mapping):
+            items = menu.get_top_level_items()
+        url_items = [i for i in items if not getattr(i, 'link_page_id', None)]
+        # All URL-only items must still be present
+        for item in url_items:
+            self.assertIsNone(item.link_page)
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +196,6 @@ class TestGetPagesForDisplayLocalization(TestCase):
     def _get_menu_and_first_item_pages(self):
         """Return (menu, en_page, it_page) where it_page != en_page."""
         menu = MainMenu.objects.get(pk=1)
-        all_pages = list(Page.objects.all().order_by('id'))
         # Pick the first item that has a link_page
         first_item = menu.get_menu_items_manager().filter(
             link_page__isnull=False

--- a/wagtailmenus/tests/test_localization.py
+++ b/wagtailmenus/tests/test_localization.py
@@ -1,0 +1,295 @@
+"""
+Tests for the LOCALIZE_MENU_ITEMS feature (closes #242).
+
+These tests verify that when `WAGTAILMENUS_LOCALIZE_MENU_ITEMS = True` (or
+`WAGTAIL_I18N_ENABLED = True`) is configured:
+
+- ``AbstractMenuItem.__init__`` swaps ``link_page`` to its active-locale
+  counterpart so that ``menu_text`` / ``href`` are locale-aware.
+- ``get_pages_for_display()`` builds the prefetch queryset from the
+  localized page tree, so multi-level submenus are populated correctly.
+- The final page filter correctly bridges the locale gap (the N+1 query
+  path based on ``p.localized.id``) instead of a direct queryset
+  intersection that would be empty when locales differ.
+- All existing behaviour is preserved when the setting is disabled.
+"""
+
+from unittest.mock import PropertyMock, patch
+
+from django.test import TestCase, override_settings
+from wagtail.models import Page
+
+from wagtailmenus.conf import settings
+from wagtailmenus.models import MainMenu, MainMenuItem
+
+
+# ---------------------------------------------------------------------------
+# Helper: a descriptor that replaces Page.localized during a test
+# ---------------------------------------------------------------------------
+
+class _LocalizedMapping:
+    """
+    Descriptor that replaces ``Page.localized`` for the duration of a test.
+
+    ``mapping`` is a dict of {original_page_id: localized_page}.  Any page
+    whose id is not in the mapping simply returns itself (i.e. already in
+    the active locale).
+    """
+
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return self.mapping.get(obj.pk, obj)
+
+
+# ---------------------------------------------------------------------------
+# 1.  Setting configuration
+# ---------------------------------------------------------------------------
+
+class TestLocalizationSetting(TestCase):
+    """LOCALIZE_MENU_ITEMS setting defaults and auto-detection."""
+
+    def test_disabled_by_default(self):
+        self.assertFalse(settings.LOCALIZE_MENU_ITEMS)
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
+    def test_explicit_override_enables_feature(self):
+        self.assertTrue(settings.LOCALIZE_MENU_ITEMS)
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=False)
+    def test_explicit_false_disables_feature(self):
+        self.assertFalse(settings.LOCALIZE_MENU_ITEMS)
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True)
+    def test_auto_detection_from_wagtail_i18n_enabled(self):
+        self.assertTrue(settings.LOCALIZE_MENU_ITEMS)
+
+    @override_settings(WAGTAIL_I18N_ENABLED=True, WAGTAILMENUS_LOCALIZE_MENU_ITEMS=False)
+    def test_explicit_false_overrides_wagtail_i18n_enabled(self):
+        """An explicit opt-out must not be overridden by WAGTAIL_I18N_ENABLED."""
+        self.assertFalse(settings.LOCALIZE_MENU_ITEMS)
+
+    @override_settings(WAGTAIL_I18N_ENABLED=False)
+    def test_auto_detection_returns_false_when_wagtail_i18n_disabled(self):
+        self.assertFalse(settings.LOCALIZE_MENU_ITEMS)
+
+
+# ---------------------------------------------------------------------------
+# 2.  AbstractMenuItem.__init__ locale swap
+# ---------------------------------------------------------------------------
+
+class TestMenuItemLocalizationInit(TestCase):
+    """AbstractMenuItem.__init__ swaps link_page to its localized version."""
+
+    fixtures = ['test.json']
+
+    def _two_distinct_pages(self):
+        pages = list(Page.objects.all().order_by('id')[:2])
+        self.assertEqual(len(pages), 2)
+        original, localized = pages
+        self.assertNotEqual(original.pk, localized.pk)
+        return original, localized
+
+    # --- disabled (default) -------------------------------------------------
+
+    def test_init_does_not_swap_when_disabled(self):
+        original, localized = self._two_distinct_pages()
+        menu = MainMenu.objects.first()
+
+        mapping = _LocalizedMapping({original.pk: localized})
+        with patch.object(Page, 'localized', mapping):
+            item = MainMenuItem(menu=menu, link_page=original)
+
+        # link_page must stay as the original when the feature is off
+        self.assertEqual(item.link_page.pk, original.pk)
+
+    # --- enabled ------------------------------------------------------------
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
+    def test_init_swaps_link_page_when_enabled(self):
+        original, localized = self._two_distinct_pages()
+        menu = MainMenu.objects.first()
+
+        mapping = _LocalizedMapping({original.pk: localized})
+        with patch.object(Page, 'localized', mapping):
+            item = MainMenuItem(menu=menu, link_page=original)
+
+        self.assertEqual(item.link_page.pk, localized.pk)
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
+    def test_init_updates_link_page_id_after_swap(self):
+        """Django FK descriptor must keep link_page_id in sync."""
+        original, localized = self._two_distinct_pages()
+        menu = MainMenu.objects.first()
+
+        mapping = _LocalizedMapping({original.pk: localized})
+        with patch.object(Page, 'localized', mapping):
+            item = MainMenuItem(menu=menu, link_page=original)
+
+        # link_page_id is the FK column; after the swap it must point at the
+        # localized page so that pages_for_display keying works correctly.
+        self.assertEqual(item.link_page_id, localized.pk)
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
+    def test_init_does_not_swap_when_already_in_active_locale(self):
+        """When localized returns the same page, nothing changes."""
+        original, _ = self._two_distinct_pages()
+        menu = MainMenu.objects.first()
+
+        # No mapping entry → descriptor returns the same page
+        mapping = _LocalizedMapping({})
+        with patch.object(Page, 'localized', mapping):
+            item = MainMenuItem(menu=menu, link_page=original)
+
+        self.assertEqual(item.link_page.pk, original.pk)
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
+    def test_init_no_op_when_link_page_is_none(self):
+        """Items with no link_page (custom URL items) are unaffected."""
+        menu = MainMenu.objects.first()
+        item = MainMenuItem(menu=menu, link_url='/custom/', link_text='Custom')
+        self.assertIsNone(item.link_page)
+
+
+# ---------------------------------------------------------------------------
+# 3.  get_pages_for_display – locale-aware queryset building
+# ---------------------------------------------------------------------------
+
+class TestGetPagesForDisplayLocalization(TestCase):
+    """
+    get_pages_for_display() returns localized pages when the feature is on.
+    """
+
+    fixtures = ['test.json']
+
+    def _get_menu_and_first_item_pages(self):
+        """Return (menu, en_page, it_page) where it_page != en_page."""
+        menu = MainMenu.objects.get(pk=1)
+        all_pages = list(Page.objects.all().order_by('id'))
+        # Pick the first item that has a link_page
+        first_item = menu.get_menu_items_manager().filter(
+            link_page__isnull=False
+        ).first()
+        en_page = first_item.link_page
+        # Use any *other* live page as the fake localized counterpart
+        it_page = Page.objects.exclude(pk=en_page.pk).filter(
+            live=True, expired=False, show_in_menus=True
+        ).first()
+        return menu, en_page, it_page
+
+    # --- disabled (default) -------------------------------------------------
+
+    def test_pages_for_display_unchanged_when_disabled(self):
+        menu = MainMenu.objects.get(pk=1)
+        # The fixture has 12 pages for this menu
+        self.assertEqual(len(menu.pages_for_display), 12)
+
+    # --- enabled: localized page is included --------------------------------
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
+    def test_pages_for_display_includes_localized_page(self):
+        """
+        When localization is active and a localized page exists, it must
+        appear in pages_for_display (keyed by the localized page id, which
+        is what __init__ sets as link_page_id after the swap).
+        """
+        menu, en_page, it_page = self._get_menu_and_first_item_pages()
+
+        # Map: en_page → it_page; everything else stays the same
+        mapping = _LocalizedMapping({en_page.pk: it_page})
+
+        with patch.object(Page, 'localized', mapping):
+            # Bypass the @cached_property so we get a fresh result
+            pages = menu.get_pages_for_display()
+            page_ids = {p.id for p in pages}
+
+        self.assertIn(it_page.pk, page_ids)
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
+    def test_pages_for_display_excludes_original_when_localized_differs(self):
+        """
+        When the localized page is different, the original (en) page should
+        not be in pages_for_display unless it is also linked elsewhere.
+        """
+        menu, en_page, it_page = self._get_menu_and_first_item_pages()
+
+        # Only the single-page (no allow_subnav) case for a clean assertion:
+        # find an item where allow_subnav is False
+        item = menu.get_menu_items_manager().filter(
+            link_page__isnull=False, allow_subnav=False
+        ).first()
+        if item is None:
+            self.skipTest("No allow_subnav=False item in fixture")
+
+        en_page = item.link_page
+        # Pick a page not otherwise in the menu as the fake translation
+        menu_page_ids = set(
+            menu.get_menu_items_manager().values_list('link_page_id', flat=True)
+        )
+        it_page = Page.objects.filter(
+            live=True, expired=False, show_in_menus=True
+        ).exclude(pk__in=menu_page_ids).first()
+        if it_page is None:
+            self.skipTest("Not enough pages in fixture for this test")
+
+        mapping = _LocalizedMapping({en_page.pk: it_page})
+
+        with patch.object(Page, 'localized', mapping):
+            pages = menu.get_pages_for_display()
+            page_ids = {p.id for p in pages}
+
+        # Original en_page should NOT appear; localized it_page SHOULD
+        self.assertNotIn(en_page.pk, page_ids)
+        self.assertIn(it_page.pk, page_ids)
+
+    # --- enabled: same-locale is a no-op ------------------------------------
+
+    @override_settings(WAGTAILMENUS_LOCALIZE_MENU_ITEMS=True)
+    def test_pages_for_display_unchanged_when_already_in_active_locale(self):
+        """
+        When Page.localized returns the same page (already in active locale)
+        the output of get_pages_for_display() must be identical to the
+        non-localization case.
+        """
+        menu = MainMenu.objects.get(pk=1)
+
+        # Empty mapping → all pages return themselves
+        mapping = _LocalizedMapping({})
+        with patch.object(Page, 'localized', mapping):
+            pages = menu.get_pages_for_display()
+
+        # Still the same 12 pages
+        self.assertEqual(len(pages), 12)
+
+
+# ---------------------------------------------------------------------------
+# 4.  Regression: existing behaviour preserved when disabled
+# ---------------------------------------------------------------------------
+
+class TestLocalizationRegressionWhenDisabled(TestCase):
+    """
+    The full top_level_items / pages_for_display pipeline must behave
+    identically to before when LOCALIZE_MENU_ITEMS is False (the default).
+    """
+
+    fixtures = ['test.json']
+
+    def test_top_level_items_count_unchanged(self):
+        menu = MainMenu.objects.get(pk=1)
+        # Fixture has 6 menu items, one of which links to show_in_menus=False
+        # so 5 top-level items are returned
+        self.assertEqual(len(menu.top_level_items), 5)
+
+    def test_pages_for_display_count_unchanged(self):
+        menu = MainMenu.objects.get(pk=1)
+        self.assertEqual(len(menu.pages_for_display), 12)
+
+    def test_pages_for_display_all_live_and_show_in_menus(self):
+        menu = MainMenu.objects.get(pk=1)
+        for page in menu.pages_for_display.values():
+            self.assertTrue(page.live)
+            self.assertFalse(page.expired)
+            self.assertTrue(page.show_in_menus)


### PR DESCRIPTION
I'm proposing an approach to fix an issue that affects any Wagtail project using `wagtailmenus` together with `wagtail-localize` (or any multi-locale setup). The issue is that menu items generated by `wagtailmenus` always resolve to the **default locale** URL, regardless of which locale the user is currently browsing.

## Problem

When a Wagtail project uses `wagtail-localize` (or `WAGTAIL_I18N_ENABLED = True`), menu items always resolve to the **default-locale** page, because:

1. `MainMenuItem` stores a FK to the default-locale `Page`.
2. `get_pages_for_display()` builds a prefetch queryset rooted at those default-locale page paths.
3. `_prime_menu_item()` resolves URLs and text from that prefetched queryset.

Result: on `/it/`, menu links point to `/en/`, item text is English, and any second-level submenu is empty (descendants of the Italian page were never prefetched).

### How wagtailmenus resolves URLs

`wagtailmenus` stores menu items as `MainMenuItem` objects that link to Wagtail `Page` instances. When rendering, it calls `item.relative_url(current_site, request)` which internally calls:

```python
page.get_url(request=request, current_site=site)
```

`Page.get_url()` resolves the URL based on the **page's own locale**, not the **request's active locale**. A page created in locale `en` will always return `/en/pagename/` regardless of the current request locale.

### Why the request locale is ignored

Wagtail's `Page.get_url()` only considers:

1. The page's own `locale` field
2. The `site` root path for that locale
3. Optional `request` parameter (used for caching, not for locale switching)

It does **not** look at `Locale.get_active()` or the request's language prefix. The `LocaleMiddleware` sets the active locale for template rendering and translation, but `Page.get_url()` has no awareness of it.

### Why `{% slugurl %}` also fails

Wagtail's built-in `slugurl` template tag looks up a page by slug and returns its URL. It always returns the **first matching page** (usually the default locale version). It has no locale-awareness.

```django
{% slugurl 'pagename' %}  {# Always returns /en/pagename/ #}
```

### The gap: no built-in locale-aware URL resolution

Neither `wagtailmenus` nor Wagtail's core tags provide a locale-aware way to resolve a page URL from a slug or menu item. The `pageurl` tag works correctly when you already have a localized page object (`{% pageurl page.localized %}`), but there's no tag to look up a page by slug in the active locale.

## Solution

Two targeted changes guarded by a new setting `WAGTAILMENUS_LOCALIZE_MENU_ITEMS`.

**1. `wagtailmenus/conf/defaults.py` — new setting**

```python
# ----------------------
# Miscellaneous settings
# ----------------------

LOCALIZE_MENU_ITEMS = False
```

**2. `wagtailmenus/conf/settings.py` — auto-detection from `WAGTAIL_I18N_ENABLED`**

The `WagtailmenusSettingsHelper` overrides `__getattr__` so that when `WAGTAILMENUS_LOCALIZE_MENU_ITEMS` is not explicitly set, it falls through to Wagtail's own `WAGTAIL_I18N_ENABLED` flag. Zero extra configuration for projects already using Wagtail i18n.

```python
class WagtailmenusSettingsHelper(BaseAppSettingsHelper):
    deprecations = ()

    def __getattr__(self, name):
        value = super().__getattr__(name)
        # Auto-detect locale-awareness from Wagtail's own i18n flag when the
        # wagtailmenus-specific setting has not been explicitly overridden.
        if name == 'LOCALIZE_MENU_ITEMS' and not self.is_overridden('LOCALIZE_MENU_ITEMS'):
            return bool(getattr(django_settings, 'WAGTAIL_I18N_ENABLED', False))
        return value
```

To opt out explicitly even when `WAGTAIL_I18N_ENABLED = True`:

```python
WAGTAILMENUS_LOCALIZE_MENU_ITEMS = False
```

**3. `wagtailmenus/models/menus.py`**

Locale-aware translation is applied **at render time only**:

- **`get_pages_for_display()`** builds the menu's page queryset using a single DB subquery. A lightweight `localize_page_map` caches the mapping from stored (default-locale) page IDs to corresponding active-locale page.
- **`get_top_level_items()`** uses `localize_page_map` to resolve each menu item to the correct localized page when building the render cache.
- **`link_page_id` is never mutated** — admin saves cannot accidentally persist a swapped value.

### Why not just fix the template?

Using `{{ item.link_page.localized.url }}` in templates only fixes top-level URLs. It breaks multi-level menus because `get_pages_for_display()` prefetches descendants of the _default-locale_ page, so second-level items never appear. The fix must happen server-side before the prefetch queryset is built.

### Why not use `get_base_page_queryset() & queryset`?

When `LOCALIZE_MENU_ITEMS` is active, `queryset` contains localized (IT) pages while `get_base_page_queryset()` returns pages for which menu items are configured (EN). The `&` intersection is empty.

