### PR TITLE
Wagtail 74 maintenance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,6 @@ jobs:
             ${{ matrix.python-version }}-v1-
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           name: Python ${{ matrix.python-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Added testing for Wagtail 7.4 (LTS).
+* Removed support for Wagtail 6.3 LTS, 7.1 and 7.2 (end of life).
+* Removed support for Django 5.1 (end of life).
+* Raised minimum Wagtail version to 7.0.
+* Removed dead Django <4.1 compatibility shim in `models/menus.py`.
+
 4.0.7 (23.04.2026)
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,8 @@ wagtailmenus is an extension for Torchbox's `Wagtail CMS <https://github.com/tor
 
 The current version is tested for compatibility with the following:
 
-- Wagtail versions >= 6.5
-- Django versions 4.2, 5.1, 5.2 and 6.0
+- Wagtail versions 7.0, 7.3 and 7.4
+- Django versions 4.2, 5.2 and 6.0
 - Python versions 3.10 to 3.14
 
 .. image:: https://raw.githubusercontent.com/jazzband/wagtailmenus/master/docs/source/_static/images/repeating-item.png

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 # Essential dependencies
 requires = [
-    'wagtail>=6.3',
+    'wagtail>=7.0',
     'django-cogwheels==0.3',
 ]
 
@@ -21,7 +21,7 @@ testing_extras = [
 ]
 
 development_extras = [
-    'wagtail>=6.3',
+    'wagtail>=7.0',
     'django-debug-toolbar',
     'django-extensions',
     'ipdb',
@@ -64,9 +64,8 @@ setup(
         'Programming Language :: Python :: 3.14',
         'Framework :: Django',
         'Framework :: Django :: 4.2',
-        'Framework :: Django :: 5.1',
         'Framework :: Django :: 5.2',
-        'Framework :: Wagtail :: 6',
+        'Framework :: Django :: 6.0',
         'Framework :: Wagtail :: 7',
         'Topic :: Internet :: WWW/HTTP',
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",

--- a/tox.ini
+++ b/tox.ini
@@ -3,16 +3,13 @@ skipsdist = True
 usedevelop = True
 
 envlist =
-    wt63-dj42-py{310,311,312}
-    wt63-dj{51,52}-py{310,311,312,313}
-    wt70-dj{42}-py{310,311,312}
-    wt70-dj{51,52}-py{310,311,312,313}
-    wt72-dj{42}-py{310,311,312}
-    wt72-dj{51,52}-py{310,311,312,313}
-    wt72-dj{60}-py{312,313,314}
-    wt73-dj{42}-py{310,311,312}
-    wt73-dj{51,52}-py{310,311,312,313}
-    wt73-dj{60}-py{312,313,314}
+    wt70-dj42-py{310,311,312}
+    wt70-dj52-py{310,311,312,313}
+    wt73-dj42-py{310,311,312}
+    wt73-dj52-py{310,311,312,313}
+    wt73-dj60-py{312,313,314}
+    wt74-dj52-py{310,311,312,313}
+    wt74-dj60-py{312,313,314}
 
 [gh-actions]
 python =
@@ -31,13 +28,11 @@ commands = coverage run --source=wagtailmenus runtests.py
 deps =
     coverage
     dj42: Django>=4.2,<4.3
-    dj51: Django>=5.1,<5.2
     dj52: Django>=5.2,<5.3
     dj60: Django>=6.0,<6.1
-    wt63: wagtail>=6.3,<6.4
     wt70: wagtail>=7.0,<7.1
-    wt72: wagtail>=7.2,<7.3
     wt73: wagtail>=7.3,<7.4
+    wt74: wagtail>=7.4,<7.5
 
 [testenv:future]
 description = Unit tests against the latest development versions of dependencies

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -22,7 +22,6 @@ from .menuitems import MenuItem
 from .mixins import DefinesSubMenuTemplatesMixin
 from .pages import AbstractLinkPage
 
-mark_safe_lazy = mark_safe
 
 ContextualVals = namedtuple('ContextualVals', (
     'parent_context',
@@ -1067,7 +1066,7 @@ class AbstractMainMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
         verbose_name=_('maximum levels'),
         choices=constants.MAX_LEVELS_CHOICES,
         default=2,
-        help_text=mark_safe_lazy(_(
+        help_text=mark_safe(_(
             "The maximum number of levels to display when rendering this "
             "menu. The value can be overidden by supplying a different "
             "<code>max_levels</code> value to the <code>{% main_menu %}"
@@ -1161,7 +1160,7 @@ class AbstractFlatMenu(DefinesSubMenuTemplatesMixin, MenuWithMenuItems):
         verbose_name=_('maximum levels'),
         choices=constants.MAX_LEVELS_CHOICES,
         default=1,
-        help_text=mark_safe_lazy(_(
+        help_text=mark_safe(_(
             "The maximum number of levels to display when rendering this "
             "menu. The value can be overidden by supplying a different "
             "<code>max_levels</code> value to the <code>{% flat_menu %}"

--- a/wagtailmenus/models/menus.py
+++ b/wagtailmenus/models/menus.py
@@ -1,13 +1,12 @@
 from collections import OrderedDict, defaultdict, namedtuple
 from types import GeneratorType
 
-from django import VERSION as DJANGO_VERSION
 from django.core.exceptions import (ImproperlyConfigured,
                                     MultipleObjectsReturned)
 from django.db import models
 from django.db.models import BooleanField, Case, Q, When
 from django.template.loader import get_template, select_template
-from django.utils.functional import cached_property, lazy
+from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
@@ -23,10 +22,7 @@ from .menuitems import MenuItem
 from .mixins import DefinesSubMenuTemplatesMixin
 from .pages import AbstractLinkPage
 
-if DJANGO_VERSION >= (4, 1):
-    mark_safe_lazy = mark_safe
-else:
-    mark_safe_lazy = lazy(mark_safe, str)
+mark_safe_lazy = mark_safe
 
 ContextualVals = namedtuple('ContextualVals', (
     'parent_context',


### PR DESCRIPTION
## Summary

Realigns declared support with the current Python, Django, and Wagtail support windows (as of 2026-05-14).

- Add testing for **Wagtail 7.4 LTS**
- Drop support for **Wagtail 6.3 LTS, 7.1, 7.2** (all EOL)
- Drop support for **Django 5.1** (EOL)
- Raise minimum Wagtail to **7.0**
- Remove dead `Django < 4.1` compatibility shim in `models/menus.py` (inline `mark_safe` at use sites)
- Bump `codecov/codecov-action` to v5

## Target support range

| | Versions |
|---|---|
| Wagtail | 7.0 LTS, 7.3, 7.4 LTS |
| Django | 4.2, 5.2, 6.0 |
| Python | 3.10, 3.11, 3.12, 3.13, 3.14 |

Django 4.2 is retained because Wagtail 7.0 LTS (still in support until 2026-11) requires it.

## Test plan

  - [x] CI passes the full tox matrix
  - [x] `tox -e wt74-dj60-py313` (newest combo) passes locally
  - [x] `tox -e wt70-dj42-py310` (oldest combo) passes locally